### PR TITLE
Add pixelPerfect to WiggleEffect [READ DESC!!!]

### DIFF
--- a/preload/scripts/stages/schoolEvil.hxc
+++ b/preload/scripts/stages/schoolEvil.hxc
@@ -17,7 +17,7 @@ class SchoolEvilStage extends Stage
 	{
 		super.buildStage();
 
-		wiggle = new WiggleEffectRuntime(2, 4, 0.017, WiggleEffectType.DREAMY);
+		wiggle = new WiggleEffectRuntime(2, 4, 0.017, WiggleEffectType.DREAMY, true);
 
 		getNamedProp('evilSchoolBG').shader = wiggle;
 		getNamedProp('evilSchoolFG').shader = wiggle;

--- a/preload/shaders/wiggle.frag
+++ b/preload/shaders/wiggle.frag
@@ -26,27 +26,28 @@ uniform float uFrequency;
  * How much the pixels are going to stretch over the waves.
  */
 uniform float uWaveAmplitude;
+/**
+ * Snaps waves to the image size.
+ */
+uniform bool uPixelPerfect;
 
 vec2 sineWave(vec2 pt) {
 	float x = 0.0;
 	float y = 0.0;
+
+	if (uPixelPerfect)
+		pt = floor(pt * openfl_TextureSize) / openfl_TextureSize;
 			
 	if (effectType == EFFECT_TYPE_DREAMY) {
-		float w = 1.0 / openfl_TextureSize.y;
-		float h = 1.0 / openfl_TextureSize.x;
 
 		// look mom, I know how to write shaders now
 
-		pt.x = floor(pt.x / h) * h;
-
 		float offsetX = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
-    
-		pt.y += floor(offsetX / w) * w; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
-		pt.y = floor(pt.y / w) * w;
+		pt.y += offsetX; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
 
 		float offsetY = sin(pt.y * (uFrequency / 2.0) + uTime * (uSpeed / 2.0)) * (uWaveAmplitude / 2.0);
-    pt.x += floor(offsetY / h) * h; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
-	} else if (effectType == EFFECT_TYPE_WAVY)  {
+		pt.x += offsetY; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
+	} else if (effectType == EFFECT_TYPE_WAVY) {
 		float offsetY = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
 		pt.y += offsetY; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
 	} else if (effectType == EFFECT_TYPE_HEAT_WAVE_HORIZONTAL) {


### PR DESCRIPTION
### IMPORTANT!!
**This is an asset part of WggleEffect fix!**
**Source part of this fix: https://github.com/FunkinCrew/Funkin/pull/2329**

### So what this does?
- Makes pixel perfect element of the shader optional.
- If pixel perfect flag is set - applies it to all shader modes.

### Examples
https://github.com/FunkinCrew/Funkin/assets/87835336/c4bee04a-ee6d-4a9f-b2fe-48935fbee1b2

https://github.com/FunkinCrew/Funkin/assets/87835336/f194e7ab-34c1-4618-a524-a594910aad12

### BEFORE
![small_wiggle_shader_fix_showcase_BEFORE](https://github.com/FunkinCrew/Funkin/assets/87835336/b1254b5b-fa09-4f26-a0e8-d97923c346a7)
### AFTER
![small_wiggle_shader_fix_showcase_AFTER](https://github.com/FunkinCrew/Funkin/assets/87835336/27b2dc9f-e6b3-4b29-a724-c6bbf2da60e5)
