### PR TITLE
Add .gitattributes with linguist-language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hxc linguist-language=Haxe


### PR DESCRIPTION
Allows .hxc files to be identified as Haxe ~~and displayed with its formatting~~ on GitHub