### PR TITLE
Don't make tankmans ugh animation ignore other inputs

### DIFF
--- a/preload/scripts/characters/tankman.hxc
+++ b/preload/scripts/characters/tankman.hxc
@@ -16,7 +16,7 @@ class TankmanCharacter extends SparrowCharacter {
 			switch(event.note.kind) {
 				case "ugh":
 					holdTimer = 0;
-					this.playAnimation('ugh', true, true);
+					this.playAnimation('ugh', true, false);
 					return;
 				case "hehPrettyGood":
 					holdTimer = 0;


### PR DESCRIPTION
Says what it says it does. Tankman's ugh animation continues while other notes are hit, making it look strange, and it also just matches the last major update

before:

https://github.com/FunkinCrew/funkin.assets/assets/51544115/6b3cdd6b-136f-4664-bff2-586b006eb114







after:

https://github.com/FunkinCrew/funkin.assets/assets/51544115/4c5672bd-4d72-4b96-9429-66811d3ef31a

