### PR TITLE
Fix Week 6 remixes having the wrong note style

### DIFF
--- a/exclude/data/ui/chart-editor/toolboxes/metadata.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/metadata.xml
@@ -25,11 +25,8 @@
                         </data>
                     </dropdown>
                     <label text="Note Style:" verticalAlign="center" horizontalAlign="right" />
-                    <dropdown id="inputNoteStyle" value="Normal" width="100%" horizontalAlign="right" dropdownSize="10" dropdownWidth="300" tooltip="Which graphical style of notes to use.">
-                        <data>
-                            <item text="Normal" />
-                            <item text="Pixel" />
-                        </data>
+                    <dropdown id="inputNoteStyle" value="Funkin'" width="100%" horizontalAlign="right" dropdownSize="10" dropdownWidth="300" tooltip="Which graphical style of notes to use.">
+                        <data />
                     </dropdown>
                 </grid>
                 <hbox width="100%">

--- a/preload/data/songs/roses/roses-metadata-erect.json
+++ b/preload/data/songs/roses/roses-metadata-erect.json
@@ -21,7 +21,7 @@
       "instrumental": "erect"
     },
     "stage": "school",
-    "noteStyle": "funkin",
+    "noteStyle": "pixel",
     "ratings": {
       "normal": 0,
       "nightmare": 0

--- a/preload/data/songs/senpai/senpai-metadata-erect.json
+++ b/preload/data/songs/senpai/senpai-metadata-erect.json
@@ -21,7 +21,7 @@
       "instrumental": "erect"
     },
     "stage": "school",
-    "noteStyle": "funkin",
+    "noteStyle": "pixel",
     "ratings": {
       "erect": 0,
       "nightmare": 0

--- a/preload/data/songs/thorns/thorns-metadata-erect.json
+++ b/preload/data/songs/thorns/thorns-metadata-erect.json
@@ -21,7 +21,7 @@
       "instrumental": "erect"
     },
     "stage": "schoolEvil",
-    "noteStyle": "funkin",
+    "noteStyle": "pixel",
     "ratings": {
       "nightmare": 0,
       "normal": 0,


### PR DESCRIPTION
This PR fixes Week 6 Erect songs having the "funkin" note style instead of "pixel", caused by the following main repo PR:(https://github.com/FunkinCrew/Funkin/pull/2581)