### PR TITLE
Fixed division by zero on rain intensity range remapping

### DIFF
--- a/preload/scripts/stages/phillyStreets.hxc
+++ b/preload/scripts/stages/phillyStreets.hxc
@@ -377,7 +377,10 @@ class PhillyStreetsStage extends Stage
 	{
 		super.onUpdate(event);
 
-		var remappedIntensityValue:Float = FlxMath.remapToRange(Conductor.instance.songPosition, 0, FlxG.sound.music != null ? FlxG.sound.music.length : 0.0, rainShaderStartIntensity, rainShaderEndIntensity);
+		var remappedIntensityValue:Float = rainShaderStartIntensity;
+		if (FlxG.sound.music != null) {
+			remappedIntensityValue = FlxMath.remapToRange(Conductor.instance.songPosition, 0, FlxG.sound.music.length, rainShaderStartIntensity, rainShaderEndIntensity);
+		}
 		rainShader.intensity = remappedIntensityValue;
 		rainShader.updateViewInfo(FlxG.width, FlxG.height, FlxG.camera);
 		rainShader.update(event.elapsed);


### PR DESCRIPTION
# The Issue

Since the new update came out, I always had that weird thing happening on windows, where the rain shader on weekend 1 would always be at maximum intensity before the song started. Here's how it looks like:

https://github.com/FunkinCrew/funkin.assets/assets/95587502/dcf022c5-3d60-47d0-83b8-b7548eb18b45

I looked at the script for the stage phillyStreets and found out that when the rain intensity gets set on update, the call to `FlxMath.remapToRange` will cause a division by zero before the song starts (`FlxG.sound.music == null`). A division by zero, as explained by the [haxe manual](https://haxe.org/manual/std-math-mathematical-errors.html), gets handled differently on different targets, which explains why it only happens on windows.

## Where and why does this division happen?

Here's the definition of `FlxMath.remapToRange`:

![Screenshot 1](https://github.com/FunkinCrew/funkin.assets/assets/95587502/05a22555-d8bf-479f-a70a-8d49faacdd57)

Here's what will happen if both `start1` and `stop1` will be zero:

![Screenshot 2](https://github.com/FunkinCrew/funkin.assets/assets/95587502/994d7c3c-4a69-43b2-9b45-d790304b874c)

Here's phillyStreets' onUpdate function:

![Screenshot 3](https://github.com/FunkinCrew/funkin.assets/assets/95587502/be1bd907-e736-4df9-99a4-762fec05fddd)

Here's what happens to the values of start1 and stop1 before the song starts:

![Screenshot 4](https://github.com/FunkinCrew/funkin.assets/assets/95587502/76563fb2-9d33-4b22-b6eb-1b32425f202e)

In conclusion, giving `stop1` the value of zero when `FlxG.sound.music == null` causes the division by zero to happen.

# The Solution

My solution is to make the range remapping happen only when `FlxG.sound.music != null`, and set the rain's intensity to `rainShaderStartIntensity` otherwise, without giving `stop1` the value of zero.

Here's how it looks on windows when fixed, and as you can see, the rain still appears after the song starts:

https://github.com/FunkinCrew/funkin.assets/assets/95587502/75c66f54-db1e-45b4-8d88-d1b5e7ad4d52