### PR TITLE
Fix Pixel-style note hold trails being too small

### DIFF
--- a/preload/data/notestyles/pixel.json
+++ b/preload/data/notestyles/pixel.json
@@ -41,7 +41,7 @@
     },
     "holdNote": {
       "assetPath": "week6:weeb/pixelUI/arrowEndsNew",
-      "scale": 6.0,
+      "scale": 8.0,
       "isPixel": true,
       "data": {}
     },


### PR DESCRIPTION
The pixel-style note trails appear small as of the WeekEnd 1 update. This PR aims to adjust it to how it was before.

Before:
![Screenshot 2024-05-22 at 5 54 51 PM](https://github.com/FunkinCrew/funkin.assets/assets/86753001/fb778804-c8dc-4e13-b409-a1ca45d688a3)


After:
![Screenshot 2024-05-22 at 5 54 27 PM](https://github.com/FunkinCrew/funkin.assets/assets/86753001/db584370-aa55-4c62-9933-a2f90fa27b7a)
