### PR TITLE
Fix Pico Offsets

### DIFF
--- a/preload/data/characters/pico.json
+++ b/preload/data/characters/pico.json
@@ -17,7 +17,7 @@
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [-40, -75]
+      "offsets": [-35, -75]
     },
     {
       "name": "singUP",

--- a/preload/data/characters/pico.json
+++ b/preload/data/characters/pico.json
@@ -17,7 +17,7 @@
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [-70, -75]
+      "offsets": [-40, -75]
     },
     {
       "name": "singUP",


### PR DESCRIPTION
Pico's offsets aren't correct causing him so slide during his down animation. This can be seen here: https://twitter.com/fnfupdatenews/status/1785737724957184305. I fixed his offsets so he no longer does this.