### PR TITLE
Fix Limo offsets and Pico offsets

### DIFF
--- a/preload/data/characters/pico.json
+++ b/preload/data/characters/pico.json
@@ -17,7 +17,7 @@
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [-70, -75]
+      "offsets": [-47, -84]
     },
     {
       "name": "singUP",

--- a/preload/data/stages/limoRide.json
+++ b/preload/data/stages/limoRide.json
@@ -346,7 +346,7 @@
   "characters": {
     "bf": {
       "zIndex": 300,
-      "position": [1217.5, 592],
+      "position": [1217.5, 607],
       "cameraOffsets": [-300, -100]
     },
     "gf": {


### PR DESCRIPTION
This PR fixes BF's limo offsets and Pico's sing down offset.


Before (Pico):

![screenshot-2024-06-05-00-04-42](https://github.com/FunkinCrew/funkin.assets/assets/83185052/8bb8e075-d420-4643-9526-4434e3f703f4)

After (Pico):

![screenshot-2024-06-05-00-06-26](https://github.com/FunkinCrew/funkin.assets/assets/83185052/bdefe75b-1237-47ef-af91-e0785a6331fc)


Before (BF):

![screenshot-2024-06-05-00-04-10](https://github.com/FunkinCrew/funkin.assets/assets/83185052/69ff38e4-273f-428f-bc0e-ed4775fc3951)

After (BF):

![screenshot-2024-06-05-00-09-08](https://github.com/FunkinCrew/funkin.assets/assets/83185052/3feccd42-2db0-413e-a20a-057cf7d86d34)


please merge this its been bugging me so much