### PR TITLE
Prevent scared animations from interrupting sing animations.

### DIFF
--- a/preload/scripts/stages/spookyMansion.hxc
+++ b/preload/scripts/stages/spookyMansion.hxc
@@ -26,11 +26,11 @@ class SpookyMansionStage extends Stage
 		lightningStrikeBeat = beat;
 		lightningStrikeOffset = FlxG.random.int(8, 24);
 
-		if (getBoyfriend() != null) {
+		if (getBoyfriend() != null && !getBoyfriend().isSinging()) {
 			getBoyfriend().playAnimation('scared', true, true);
 		}
 
-		if (getGirlfriend() != null) {
+		if (getGirlfriend() != null && !getGirlfriend().isSinging()) {
 			getGirlfriend().playAnimation('scared', true, true);
 		}
 	}


### PR DESCRIPTION
Sometimes in the mansion stage, a lightning strike would happen while boyfriend was singing, and the scared animation would interrupt the sing animation. [This can be seen here.](https://youtu.be/OZ-Kq4ojqZk?feature=shared&t=1160)

This PR checks to make sure a character isn't singing before playing the scared animation. Also it checks gf too in case someone uses this stage with a singing gf or whatever.