### PR TITLE
Fix "Skip Forward" button's name

### DIFF
--- a/exclude/data/ui/chart-editor/components/playbar.xml
+++ b/exclude/data/ui/chart-editor/components/playbar.xml
@@ -10,7 +10,7 @@
 		<button allowFocus="false" styleName="playbarButton" tooltip="Skip to Start" id="playbarStart" text="|<" />
 		<button allowFocus="false" styleName="playbarButton" tooltip="Skip Back" id="playbarBack" text="<<" />
 		<button allowFocus="false" styleName="playbarButton" tooltip="Play/Pause" id="playbarPlay" text=">" />
-		<button allowFocus="false" styleName="playbarButton" tooltip="Skip Back" id="playbarForward" text=">>" />
+		<button allowFocus="false" styleName="playbarButton" tooltip="Skip Forward" id="playbarForward" text=">>" />
 		<button allowFocus="false" styleName="playbarButton" tooltip="Skip to End" id="playbarEnd" text=">|" />
 	</hbox>
 	<hbox horizontalAlign="right">


### PR DESCRIPTION
The chart editor's Skip Forward button is named "Skip Back"

![image](https://github.com/FunkinCrew/funkin.assets/assets/170126004/ffaa99b7-d6eb-4ae3-9111-446643a627c1)
