### PR TITLE
Fix GF crying animation's offsets

### DIFF
--- a/preload/data/characters/gf-christmas.json
+++ b/preload/data/characters/gf-christmas.json
@@ -22,7 +22,7 @@
       "name": "sad",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [0, -21]
     }
   ]
 }

--- a/preload/data/characters/gf-tankmen.json
+++ b/preload/data/characters/gf-tankmen.json
@@ -22,7 +22,7 @@
       "name": "sad",
       "prefix": "GF Crying at Gunpoint",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [0, -27]
     }
   ]
 }

--- a/preload/data/characters/gf.json
+++ b/preload/data/characters/gf.json
@@ -23,7 +23,7 @@
       "name": "sad",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [-2, -21]
     },
     {
       "name": "singLEFT",
@@ -59,7 +59,7 @@
       "name": "drop70",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [-2, -21]
     },
     {
       "name": "hairBlow",


### PR DESCRIPTION
Adjusted offsets for:
- gf.json `sad`
- gf.json `drop70`
- gf-christmas.json `sad`
- gf-tankmen.json `sad`

Speakers should no longer shuffle around when this animation plays.