### PR TITLE
Remove Nene's combo### and drop### animations for now

### DIFF
--- a/preload/data/characters/nene.json
+++ b/preload/data/characters/nene.json
@@ -19,32 +19,12 @@
       "offsets": [0, 0]
     },
     {
-      "name": "combo50",
-      "prefix": "ComboCheer0",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "drop70",
-      "prefix": "Laugh0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 6, 7, 8, 9, 10, 11, 6, 7, 8, 9,
-        10, 11
-      ],
-      "offsets": [0, 0]
-    },
-    {
       "name": "laughCutscene",
       "prefix": "Laugh0",
       "frameIndices": [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
         7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
       ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "combo100",
-      "prefix": "ComboFawn0",
-      "frameIndices": [0, 1, 2, 3, 4, 5, 6, 4, 5, 6, 4, 5, 6, 4, 5, 6],
       "offsets": [0, 0]
     },
     {


### PR DESCRIPTION
This is part of [this PR on the main Funkin' repo](https://github.com/FunkinCrew/Funkin/pull/2927), look there for an explanation.
TL;DR Nene's combo/drop animations hang indefinitely when they end, might be a Character script issue? This is basically a bandaid fix until a more permanent solution is made.