### PR TITLE
Fix Thorns Cutscene Death

### DIFF
--- a/preload/scripts/songs/thorns.hxc
+++ b/preload/scripts/songs/thorns.hxc
@@ -34,6 +34,8 @@ class ThornsSong extends Song {
   function startCutscene() {
     trace('Hit start of song! Starting cutscene.');
 
+    PlayState.instance.isInCutscene = true;
+
     PlayState.instance.camHUD.visible = false;
     PlayState.instance.camCutscene.visible = true;
 


### PR DESCRIPTION
## Linked Issues
Closes [#3030](https://github.com/FunkinCrew/Funkin/issues/3030)

## Fixes
Before, you were able to press notes when being in the senpai cutscene, which made the player be able to kill themselves. This lead to a bunch of problems. This pr adds `PlayState.instance.isInCutscene = true` to the script to prevent the player from killing themselves.
