### PR TITLE
[BUGFIX] Fix Song Metadata Height

### DIFF
--- a/exclude/data/ui/chart-editor/toolboxes/metadata.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="345" height="472">
+<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="345" height="492">
     <vbox width="100%" height="100%">
-        <frame text="Variation: Default" width="100%" height="230" id="frameVariation">
+        <frame text="Variation: Default" width="100%" height="250" id="frameVariation">
             <vbox width="100%" height="100%">
                 <grid columns="2" height="100%">
                     <label text="Song Name:" verticalAlign="center" horizontalAlign="right" />


### PR DESCRIPTION
## Does this PR close any issues? If so, link them below.
- https://github.com/FunkinCrew/Funkin/issues/2841
- Partly fixes https://github.com/FunkinCrew/Funkin/issues/2660
## Briefly describe the issue(s) fixed.
- This PR fixes the ``Song Metadata`` box in the chart editor, letting you finally choose notestyles easily. **(see photo below)**
## Include any relevant screenshots or videos.
- Fixed `Song Metadata` box: **(after/before)**
![fixed box](https://github.com/user-attachments/assets/7e1e4d2e-c6ad-4cf1-a597-17c3b6e2ccac)