### PR TITLE
Optimize Week 5 Erect Stage

### DIFF
--- a/preload/scripts/stages/mallXmasErect.hxc
+++ b/preload/scripts/stages/mallXmasErect.hxc
@@ -20,6 +20,16 @@ class MallXmasErectStage extends Stage
 
 	var colorShader:AdjustColorShader;
 
+	function buildStage()
+	{
+		super.buildStage();
+		
+		colorShader = new AdjustColorShader();
+
+		colorShader.hue = 5;
+		colorShader.saturation = 20;
+	}
+
 	function onUpdate(event:UpdateScriptEvent):Void
 	{
 		super.onUpdate(event);
@@ -31,9 +41,6 @@ class MallXmasErectStage extends Stage
 		  PlayState.instance.currentStage.getGirlfriend().shader = colorShader;
 		  PlayState.instance.currentStage.getDad().shader = colorShader;
 			getNamedProp('santa').shader = colorShader;
-
-		  colorShader.hue = 5;
-		  colorShader.saturation = 20;
     }
 
 	}

--- a/preload/scripts/stages/mallXmasErect.hxc
+++ b/preload/scripts/stages/mallXmasErect.hxc
@@ -34,8 +34,6 @@ class MallXmasErectStage extends Stage
 	{
 		super.onUpdate(event);
 
-    colorShader = new AdjustColorShader();
-
 		if(PlayState.instance.currentStage.getBoyfriend() != null && PlayState.instance.currentStage.getBoyfriend().shader == null){
       PlayState.instance.currentStage.getBoyfriend().shader = colorShader;
 		  PlayState.instance.currentStage.getGirlfriend().shader = colorShader;


### PR DESCRIPTION
We shouldn't have to make a new `AdjustColorShader` instance *every frame*! This PR only creates it once. (All the other Erect stages make it only once, not sure why this one in particular doesn't.)