### PR TITLE
Fix alpha not being applied correctly on adjustColor.frag

### DIFF
--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -29,9 +29,9 @@ vec3 applyHSBCEffect(vec3 color)
 
 void main()
 {
-	vec4 textureColor = texture2D(bitmap, openfl_TextureCoordv);
+    vec4 textureColor = texture2D(bitmap, openfl_TextureCoordv);
 
-	vec3 outColor = applyHSBCEffect(textureColor.rgb);
+    vec3 outColor = applyHSBCEffect(textureColor.rgb);
 
-	gl_FragColor = vec4(outColor * textureColor.a, textureColor.a);
+    gl_FragColor = vec4(outColor * textureColor.a * openfl_Alphav, textureColor.a * openfl_Alphav);
 }

--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -33,5 +33,5 @@ void main()
 
     vec3 outColor = applyHSBCEffect(textureColor.rgb);
 
-    gl_FragColor = vec4(outColor * textureColor.a * openfl_Alphav, textureColor.a * openfl_Alphav);
+    gl_FragColor = vec4(outColor * textureColor.a * openfl_Alphav, textureColor.a * openfl_Alphav); // thanks nebulazorua for finding the fix
 }


### PR DESCRIPTION
Normally, when trying to set alpha on a sprite that uses this shader (e.x. Darnell BF Mix), the alpha just doesn't get applied, it remains as if it is still set to 1

This pull request should fix that
Tested in 0.5.0 (Windows Desktop)