### PR TITLE
Skip toggle for Eggnog Erect ending cutscene and Pico Doppelganger cutscene crash fix.

### DIFF
--- a/preload/scripts/songs/eggnog.hxc
+++ b/preload/scripts/songs/eggnog.hxc
@@ -11,27 +11,30 @@ import funkin.graphics.FunkinSprite;
 import funkin.modding.base.ScriptedFlxAtlasSprite;
 import funkin.Paths;
 import funkin.play.cutscene.CutsceneType;
-import funkin.play.cutscene.VideoCutscene;
 import funkin.play.GameOverSubState;
 import funkin.play.PlayState;
 import funkin.play.PlayStatePlaylist;
 import funkin.play.song.Song;
 import funkin.play.stage.StageProp;
 import funkin.save.Save;
-
+import flixel.text.FlxText;
+import flixel.text.FlxTextBorderStyle;
 // We have to use FlxBasePoint in scripts because FlxPoint is inlined and not available in scripts
 
 class EggnogSong extends Song
 {
+	  //var santaDead:ScriptedFlxAtlasSprite;
+
 	var hasPlayedCutscene:Bool = false;
+	var cutsceneSkipped:Bool = false;
+	var canSkipCutscene:Bool = false;
+	var santaSound:FunkinSound;
+	var shootSound:FunkinSound;
 
-  //var santaDead:ScriptedFlxAtlasSprite;
-
+	var debugTesting:Bool = false;
 	function new()
 	{
-		super('eggnog');
-
-		hasPlayedCutscene = false;
+		super('eggnog');	
 	}
 
 	public override function onCountdownStart(event:CountdownScriptEvent):Void {
@@ -85,9 +88,19 @@ class EggnogSong extends Song
 			// DO NOT CANCEL THE EVENT!
 		}
 	}
+	var skipText:FlxText;
 
 	function startCutscene(){
 
+		skipText = new FlxText(936, 618, 0, 'Skip [ ' + PlayState.instance.controls.getDialogueNameFromToken("CUTSCENE_ADVANCE", true) + ' ]', 20);
+    skipText.setFormat(Paths.font('vcr.ttf'), 40, 0xFFFFFFFF, "right", FlxTextBorderStyle.OUTLINE, 0xFF000000);
+    skipText.scrollFactor.set();
+		skipText.borderSize = 2;
+		skipText.alpha = 0;
+     PlayState.instance.currentStage.add(skipText);
+
+    skipText.cameras = [PlayState.instance.camCutscene];
+	
     var normalSanta = PlayState.instance.currentStage.getNamedProp('santa');
     normalSanta.visible = false;
 
@@ -126,8 +139,13 @@ class EggnogSong extends Song
 		//PlayState.instance.tweenCameraToPosition(santaDead.x + 300, santaDead.y, 2.8, FlxEase.expoOut);
 		PlayState.instance.tweenCameraZoom(0.73, 2, true, FlxEase.quadInOut);
 
-		FunkinSound.playOnce(Paths.sound('santa_emotion'), 1);
+		santaSound = FunkinSound.load(Paths.sound('santa_emotion'), 1);
+		santaSound.volume = 1;
+		santaSound.play(false);
 
+		shootSound = FunkinSound.load(Paths.sound('santa_shot_n_falls'), 1);
+		shootSound.volume = 1;
+		
 		new FlxTimer().start(2.8, function(tmr)
 		{
 			PlayState.instance.tweenCameraToPosition(santaDead.x + 150, santaDead.y, 9, FlxEase.quartInOut);
@@ -140,10 +158,12 @@ class EggnogSong extends Song
 			//PlayState.instance.tweenCameraToPosition(santaDead.x + 220, santaDead.y, 0.8, FlxEase.expoOut);
 			//PlayState.instance.camGame.shake(0.007, 0.4);
 		});
-		new FlxTimer().start(11.375, function(tmr)
-		{
-			FunkinSound.playOnce(Paths.sound('santa_shot_n_falls'), 1);
+	
+		
+		new FlxTimer().start(11.375, function(tmr){
+				if(!cutsceneSkipped)shootSound.play(false);
 		});
+	
 
 		new FlxTimer().start(12.83, function(tmr)
 		{
@@ -156,17 +176,48 @@ class EggnogSong extends Song
 		{
 			PlayState.instance.camHUD.fade(0xFF000000, 1, false, null, true);
 		});
-
-		new FlxTimer().start(16, function(tmr)
-		{
-			PlayState.instance.camHUD.fade(0xFF000000, 0.5, true, null, true);
-			PlayState.instance.endSong(true);
-		});
-
+		
+			new FlxTimer().start(16, function(tmr)
+			{
+				if(!cutsceneSkipped)
+				{
+					PlayState.instance.camHUD.fade(0xFF000000, 0.5, true, null, true);
+					PlayState.instance.endSong(true);
+				}
+			});
+		
 	}
 
 	function onUpdate(event:UpdateScriptEvent) {
 		super.onUpdate(event);
+		if(PlayState.instance.isInCutscene)
+		{
+			if (PlayState.instance.controls.CUTSCENE_ADVANCE && cutsceneSkipped == false)
+    		{
+				if(canSkipCutscene == false){
+					trace('cant skip yet!');
+					FlxTween.tween(skipText, {alpha: 1}, 0.5, {ease: FlxEase.quadOut});
+					new FlxTimer().start(0.5, _ -> {
+						canSkipCutscene = true;
+						trace('can skip!');
+					});
+				}
+   			}
+		}
+
+		if(PlayState.instance.controls.CUTSCENE_ADVANCE  && canSkipCutscene)
+		{
+			PlayState.instance.camCutscene.fade(0xFF000000, 0.5, false, null, true);
+			FlxTween.tween(skipText, {alpha: 0}, 0.5, {ease: FlxEase.quadOut});
+			cutsceneSkipped = true;
+			santaSound.stop();
+			shootSound.stop();
+			new FlxTimer().start(0.5, function(tmr)
+			{
+				PlayState.instance.endSong(true);
+			});		
+
+		} 
 	}
 
 	/**
@@ -175,7 +226,8 @@ class EggnogSong extends Song
   function onCreate(event:ScriptEvent):Void
   {
     super.onCreate(event);
-
+	cutsceneSkipped = false;
+	canSkipCutscene = false;
     hasPlayedCutscene = false;
   }
 }

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -162,7 +162,7 @@ class PhillyTrainErectStage extends Stage
 
 		PlayState.instance.currentStage.add(cigarette);
 		PlayState.instance.currentStage.add(picoPlayer);
-    PlayState.instance.currentStage.add(picoOpponent);
+    	PlayState.instance.currentStage.add(picoOpponent);
 		PlayState.instance.currentStage.add(bloodPool);
 		PlayState.instance.currentStage.refresh();
 
@@ -187,7 +187,8 @@ class PhillyTrainErectStage extends Stage
 		FunkinSound.playOnce(Paths.sound('cutscene/picoGasp'), 1);
 
 		PlayState.instance.resetCamera(false, true);
-    PlayState.instance.cameraFollowPoint.setPosition(midPoint[0], midPoint[1]);
+   	 	PlayState.instance.cameraFollowPoint.setPosition(midPoint[0], midPoint[1]);
+		PlayState.instance.isInCutscene = true;
 
 		new FlxTimer(cutsceneTimerManager).start(4, _ -> {
 
@@ -254,7 +255,8 @@ class PhillyTrainErectStage extends Stage
 			}
 
 			hasPlayedCutscene = true;
-			cutsceneMusic.stop();
+			cutsceneMusic.stop();		
+
 		});
 	}
 


### PR DESCRIPTION
This pull request adds in a skip toggle for the Eggnog erect ending cutscene, whilst also fixing a small bug in the intro cutscene for the week 3 Pico remixes, that allowed the player to lose health when hitting the note keys.

![image](https://github.com/user-attachments/assets/21c55951-548a-4148-868d-c4e33b915b5a)
