### PR TITLE
Fix alpha, color transform in adjustColor shader

### DIFF
--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -32,5 +32,5 @@ void main()
 	vec4 textureColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
 
 	vec3 outColor = applyHSBCEffect(textureColor.rgb);
-	gl_FragColor = vec4(outColor, textureColor.a);
+	gl_FragColor = vec4(min(outColor, textureColor.a), textureColor.a);
 }

--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -29,9 +29,8 @@ vec3 applyHSBCEffect(vec3 color)
 
 void main()
 {
-	vec4 textureColor = texture2D(bitmap, openfl_TextureCoordv);
+	vec4 textureColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
 
 	vec3 outColor = applyHSBCEffect(textureColor.rgb);
-
-	gl_FragColor = vec4(outColor * textureColor.a, textureColor.a);
+	gl_FragColor = vec4(outColor, textureColor.a);
 }

--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -27,10 +27,32 @@ vec3 applyHSBCEffect(vec3 color)
     return color;
 }
 
+vec4 applyColorTransform(vec4 color)
+{
+    if (color.a == 0.) {
+        return vec4(0.);
+    }
+    if (!hasTransform) {
+        return color;
+    }
+    if (!hasColorTransform) {
+        return color * openfl_Alphav;
+    }
+    
+    color = vec4(color.rgb / color.a, color.a);
+    color = clamp(openfl_ColorOffsetv + color * openfl_ColorMultiplierv, 0., 1.);
+
+    if (color.a > 0.) {
+        return vec4(color.rgb * color.a * openfl_Alphav, color.a * openfl_Alphav);
+    }
+    return vec4(0.);
+}
+
 void main()
 {
-	vec4 textureColor = flixel_texture2D(bitmap, openfl_TextureCoordv);
+    vec4 textureColor = texture2D(bitmap, openfl_TextureCoordv);
 
-	vec3 outColor = applyHSBCEffect(textureColor.rgb);
-	gl_FragColor = vec4(min(outColor, textureColor.a), textureColor.a);
+    vec3 hsbcEffect = applyHSBCEffect(textureColor.rgb);
+    vec4 outColor = vec4(hsbcEffect, textureColor.a);
+    gl_FragColor = applyColorTransform(outColor);
 }


### PR DESCRIPTION
the adjustColor fragment shader multiplies the color by alpha on the output.  the color is already premultiplied by alpha, so this only causes colors to turn darker as the opacity / alpha decreases, causing black edges and making the output look "dirty". this is specially noticeable in glows and particles!!
**BEFORE:**
![image](https://github.com/user-attachments/assets/ba5f9a04-6178-4f54-9a7d-6538132bd33d)
this tiny fix simply removes that alpha multiplication, essentially fixing this issue
**AFTER:**
![image](https://github.com/user-attachments/assets/9cb322fb-590a-4cd6-a870-0374e12bd8c5)

`texture2D` has also been changed to `flixel_texture2D`, to allow Flixel color and alpha transformations to be applied (pictured below). this doesn't affect the appearance of sprites without these transformations applied
![image](https://github.com/user-attachments/assets/fc4c763d-4ee2-4dd6-a5a7-562e46184bb7)