### PR TITLE
Fix MtH not being credited in Monster's metadata

### DIFF
--- a/preload/data/songs/monster/monster-metadata.json
+++ b/preload/data/songs/monster/monster-metadata.json
@@ -2,7 +2,7 @@
   "version": "2.2.4",
   "songName": "Monster",
   "artist": "BassetFilms",
-  "charter": "ChaoticGamerCG + Spazkid",
+  "charter": "ChaoticGamerCG + MtH + Spazkid",
   "playData": {
     "difficulties": ["easy", "normal", "hard"],
     "characters": { "player": "bf", "girlfriend": "gf", "opponent": "monster" },


### PR DESCRIPTION
The [_Friday Night Funkin'_ wiki](https://fridaynightfunkin.wiki.gg/wiki/Monster_(Song)#Trivia) says that MtH did the improved charting for the song when the Week 7 update released, but she isn't credited at the time of this writing, with only ChaoticGamerCG and Spazkid being credited.