### PR TITLE
[BUGFIX] Player can no longer die during Week 3 Pico cutscenes

### DIFF
--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -59,6 +59,7 @@ class PhillyTrainErectStage extends Stage
       trace('Pausing countdown to play in game cutscene');
 
       hasPlayedInGameCutscene = true;
+	PlayState.instance.isInCutscene = true;
 
       event.cancel(); // CANCEL THE COUNTDOWN!
 
@@ -220,6 +221,7 @@ class PhillyTrainErectStage extends Stage
 		});
 
 		new FlxTimer(cutsceneTimerManager).start(13, _ -> {
+			PlayState.instance.isInCutscene = false;
 
 			if(explode == false || playerShoots == true){
 				PlayState.instance.startCountdown();
@@ -266,6 +268,7 @@ class PhillyTrainErectStage extends Stage
 
 		new FlxTimer().start(0.5, _ -> {
 			PlayState.instance.justUnpaused = true;
+			PlayState.instance.isInCutscene = false;
 			PlayState.instance.camCutscene.fade(0xFF000000, 0.5, true, null, true);
 
 			cutsceneTimerManager.clear();


### PR DESCRIPTION
This bugfix fixes the issue [3146](https://github.com/FunkinCrew/Funkin/issues/3146) by adding 3 lines to the stage code which toggle ``PlayState.instance.isInCutscene`` to either true or false. This variable is responsible for disabling keyboard input, which in turn fixes the aforementioned bug. 