### PR TITLE
Ensure volume enables for burpShit animation as well

### DIFF
--- a/preload/scripts/characters/pico-playable.hxc
+++ b/preload/scripts/characters/pico-playable.hxc
@@ -105,7 +105,7 @@ class PicoPlayerCharacter extends MultiSparrowCharacter {
 	function playAnimation(name:String, restart:Bool, ignoreOther:Bool) {
 		// restore vocal volume to ensure burps always play
 		// not needed on the dark variant because this one always exists anyway..
-		if(name == "burpSmile" || name == "burpSmileLong") PlayState.instance.vocals.playerVolume = 1;
+		if (name == "burpShit" || name == "burpSmile" || name == "burpSmileLong") PlayState.instance.vocals.playerVolume = 1;
 
 		if (name == "firstDeath") {
 			if (GameOverSubState.blueBallSuffix == '-pico-explode') {


### PR DESCRIPTION
# Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/3545

# Description
[This commit](https://github.com/FunkinCrew/funkin.assets/commit/f6d758f5379fec730805e639f69dfff8000bec13) made it so that `burpSmile` and `burpSmileLong` would set `playerVolume` to 1 so that Pico's burps would always be heard.

This PR adds `burpShit` to the list of animations, ensuring that Pico can burp to his heart's content.

## South (Pico Mix) in 0.5.1

https://github.com/user-attachments/assets/2b2c0278-43a2-4f0b-8ead-b31e08c6d01a

