### PR TITLE
Add missing hotkeys to User Guide

### DIFF
--- a/preload/data/ui/chart-editor/dialogs/user-guide.xml
+++ b/preload/data/ui/chart-editor/dialogs/user-guide.xml
@@ -18,6 +18,7 @@
 					<item action="Select Note/Event" keybind="Left Click on Note" />
 					<item action="Select Multiple Notes/Events" keybind="Ctrl + Left Click" />
 					<item action="Remove Note/Event" keybind="Right Click on Note" />
+					<item action="Show Note Options" keybind="Shift + Right Click on Note" />
 					<item action="Place Focus Camera - Player Event at Playhead" keybind="Dot (.)"/>
 					<item action="Place Focus Camera - Opponent Event at Playhead" keybind="Comma (,)"/>
 					<item action="Select Box" keybind="Left Click and Drag" />

--- a/preload/data/ui/chart-editor/dialogs/user-guide.xml
+++ b/preload/data/ui/chart-editor/dialogs/user-guide.xml
@@ -18,6 +18,8 @@
 					<item action="Select Note/Event" keybind="Left Click on Note" />
 					<item action="Select Multiple Notes/Events" keybind="Ctrl + Left Click" />
 					<item action="Remove Note/Event" keybind="Right Click on Note" />
+					<item action="Place Focus Camera - Player Event at Playhead" keybind="Dot (.)"/>
+					<item action="Place Focus Camera - Opponent Event at Playhead" keybind="Comma (,)"/>
 					<item action="Select Box" keybind="Left Click and Drag" />
 					<item action="Scroll Up/Down" keybind="Mouse Wheel" />
 					<item action="Scroll Up/Down (Fast)" keybind="Shift + Mouse Wheel" />


### PR DESCRIPTION
### Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/3697

Adds the Focus Camera and note context/options menu hotkeys that are currently not documented anywhere (except for the camera events in the changelog for v0.3.2).
If you have a better and/or shorter description to the hotkeys you're very welcome to suggest changes.