### PR TITLE
Change the difficulty rating of Spookeez Easy from 0 to 1

### DIFF
--- a/preload/data/songs/spookeez/spookeez-metadata.json
+++ b/preload/data/songs/spookeez/spookeez-metadata.json
@@ -15,7 +15,7 @@
     },
     "stage": "spookyMansion",
     "noteStyle": "funkin",
-    "ratings": { "easy": 0, "normal": 1, "hard": 2 },
+    "ratings": { "easy": 1, "normal": 1, "hard": 2 },
     "album": "volume1",
     "previewStart": 0,
     "previewEnd": 15000


### PR DESCRIPTION
# Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/2776

# Why?
I've seen many people complain about Spookeez Easy being rated 0, since that would mean it's easier than Bopeebo Easy (1 difficulty) and on par with Tutorial Easy (0 difficulty).

# Related Note
People also mention the difficulty of Eggnog (Pico Mix) being far too low (1 / 2 / 2).
See https://github.com/FunkinCrew/Funkin/issues/3315 for the report.


