### PR TITLE
[ENHANCEMENT] Add crisp to artist credits for Cocoa Erect

### DIFF
--- a/preload/data/songs/cocoa/cocoa-metadata-erect.json
+++ b/preload/data/songs/cocoa/cocoa-metadata-erect.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2.4",
   "songName": "Cocoa Erect",
-  "artist": "Saster",
+  "artist": "Saster (ft. Crisp)",
   "charter": "Fabs + Spazkid",
   "playData": {
     "difficulties": ["erect", "nightmare"],


### PR DESCRIPTION
**This commit fixes the Cocoa Erect MetaData File as it has some inconsistencies with it.**

# Spotify Release:
![image](https://github.com/user-attachments/assets/72eaae45-7804-4d40-966c-0439402e2628)

# YouTube Release:
![image](https://github.com/user-attachments/assets/191efef6-574d-4fd8-87e5-f01cfa8d0b8d)

# In-Game (Before)
![screenshot-2024-10-16-14-59-40](https://github.com/user-attachments/assets/de44c09e-9f40-42f0-a2a9-ce51ccf5ca89)

# In-Game (After)
![image](https://github.com/user-attachments/assets/afba36c7-c2a1-462e-a3a5-3199739fa31a)

