### PR TITLE
Fix call in `2hot.hxc`

### DIFF
--- a/preload/scripts/songs/2hot.hxc
+++ b/preload/scripts/songs/2hot.hxc
@@ -353,7 +353,7 @@ class TwoHOTSong extends Song
 
 	function onNoteMiss(event:NoteScriptEvent)
 	{
-		super.onNoteMiss(event.note);
+		super.onNoteMiss(event);
 
 		trace('Missed note on 2hot stage...' + event.note.noteData);
 


### PR DESCRIPTION
I don't know why but this would only trigger an error in HashLink which is why it went unnoticed.