### PR TITLE
[BUGFIX] Fix Pico's `fistPump` offsets

### DIFF
--- a/preload/data/players/pico.json
+++ b/preload/data/players/pico.json
@@ -56,7 +56,7 @@
       {
         "name": "fistPump",
         "prefix": "pico cheer",
-        "offsets": [975, 260]
+        "offsets": [970, 270]
       },
       {
         "name": "loss",


### PR DESCRIPTION
Pico's `fistPump` animation offsets were weird, which made the transition to idle look awkward. This PR corrects the offsets for that animation.

### Before
https://github.com/user-attachments/assets/b5bca1f8-a51a-4055-875a-0cabf530c8dd

### After
https://github.com/user-attachments/assets/f10824fc-3aef-45b7-a8a4-1cc260e5dc18