### PR TITLE
Apply `colorShader` once instead of every frame

### DIFF
--- a/preload/scripts/stages/limoRideErect.hxc
+++ b/preload/scripts/stages/limoRideErect.hxc
@@ -132,36 +132,31 @@ class LimoRideErectStage extends Stage
 		mist5.y = -450 + (Math.sin(_timer*0.2)*150);
 		//trace(mist1.y);
 
-    if(PlayState.instance.currentStage.getBoyfriend() != null && PlayState.instance.currentStage.getBoyfriend().shader == null){
-      PlayState.instance.currentStage.getBoyfriend().shader = colorShader;
-		  PlayState.instance.currentStage.getGirlfriend().shader = colorShader;
-		  PlayState.instance.currentStage.getDad().shader = colorShader;
-		  getNamedProp('limoDancer1').shader = colorShader;
-      getNamedProp('limoDancer2').shader = colorShader;
-  	  getNamedProp('limoDancer3').shader = colorShader;
-      getNamedProp('limoDancer4').shader = colorShader;
-      getNamedProp('limoDancer5').shader = colorShader;
-      getNamedProp('fastCar').shader = colorShader;
+		getNamedProp('limoDancer1').shader = colorShader;
+		getNamedProp('limoDancer2').shader = colorShader;
+		getNamedProp('limoDancer3').shader = colorShader;
+		getNamedProp('limoDancer4').shader = colorShader;
+		getNamedProp('limoDancer5').shader = colorShader;
+		getNamedProp('fastCar').shader = colorShader;
 
-			// PlayState.instance.currentStage.getBoyfriend().visible = false;
-		  // PlayState.instance.currentStage.getGirlfriend().visible = false;
-		  // PlayState.instance.currentStage.getDad().visible = false;
-		 	// getNamedProp('limo').visible = false;
-			// getNamedProp('limoDancer1').visible = false;
-      // getNamedProp('limoDancer2').visible = false;
-  	  // getNamedProp('limoDancer3').visible = false;
-      // getNamedProp('limoDancer4').visible = false;
-      // getNamedProp('limoDancer5').visible = false;
-      // getNamedProp('fastCar').visible = false;
-			// getNamedProp('bgLimo').visible = false;
-			// getNamedProp('limoSunset').visible = false;
-			// getNamedProp('shootingStar').visible = false;
+		// PlayState.instance.currentStage.getBoyfriend().visible = false;
+		// PlayState.instance.currentStage.getGirlfriend().visible = false;
+		// PlayState.instance.currentStage.getDad().visible = false;
+		// getNamedProp('limo').visible = false;
+		// getNamedProp('limoDancer1').visible = false;
+		// getNamedProp('limoDancer2').visible = false;
+		// getNamedProp('limoDancer3').visible = false;
+		// getNamedProp('limoDancer4').visible = false;
+		// getNamedProp('limoDancer5').visible = false;
+		// getNamedProp('fastCar').visible = false;
+		// getNamedProp('bgLimo').visible = false;
+		// getNamedProp('limoSunset').visible = false;
+		// getNamedProp('shootingStar').visible = false;
 
-		  colorShader.hue = -30;
-		  colorShader.saturation = -20;
-		  colorShader.contrast = 0;
-		  colorShader.brightness = -30;
-    }
+		colorShader.hue = -30;
+		colorShader.saturation = -20;
+		colorShader.contrast = 0;
+		colorShader.brightness = -30;
   }
 
 	function doShootingStar(beat:Int):Void
@@ -174,6 +169,13 @@ class LimoRideErectStage extends Stage
 		shootingStarBeat = beat;
 		shootingStarOffset = FlxG.random.int(4, 8);
 
+	}
+
+	override function addCharacter(character:BaseCharacter, charType:CharacterType):Void {
+		// Apply the shader automatically to each character as it gets added.
+		super.addCharacter(character, charType);
+		trace('Applied stage shader to ' + character.characterName);
+		character.shader = colorShader;
 	}
 
 	function onBeatHit(event:SongTimeScriptEvent)

--- a/preload/scripts/stages/mainStageErect.hxc
+++ b/preload/scripts/stages/mainStageErect.hxc
@@ -9,6 +9,7 @@ import funkin.play.PlayState;
 import funkin.play.stage.Stage;
 import funkin.graphics.adobeanimate.FlxAtlasSprite;
 import funkin.modding.base.ScriptedFlxAtlasSprite;
+import funkin.play.character.CharacterType;
 
 class MainStageErectStage extends Stage
 {
@@ -56,18 +57,6 @@ class MainStageErectStage extends Stage
 
 	}
 
-	function onUpdate(event:UpdateScriptEvent):Void
-	{
-		super.onUpdate(event);
-
-    if(PlayState.instance.currentStage.getBoyfriend() != null && PlayState.instance.currentStage.getBoyfriend().shader == null){
-      PlayState.instance.currentStage.getBoyfriend().shader = colorShaderBf;
-			PlayState.instance.currentStage.getGirlfriend().shader = colorShaderGf;
-			PlayState.instance.currentStage.getDad().shader = colorShaderDad;
-    }
-
-	}
-
 	function onBeatHit(event:SongTimeScriptEvent):Void
 	{
 		super.onBeatHit(event);
@@ -76,5 +65,19 @@ class MainStageErectStage extends Stage
   function onStepHit(event:SongTimeScriptEvent):Void
 	{
 		super.onStepHit(event);
+	}
+
+	override function addCharacter(character:BaseCharacter, charType:CharacterType):Void {
+		// Apply the shader automatically to each character as it gets added.
+		super.addCharacter(character, charType);
+		trace('Applied stage shader to ' + character.characterName);
+		switch (charType) {
+			case CharacterType.BF:
+				character.shader = colorShaderBf;
+			case CharacterType.DAD:
+				character.shader = colorShaderDad;
+			case CharacterType.GF:
+				character.shader = colorShaderGf;
+		}
 	}
 }

--- a/preload/scripts/stages/phillyStreetsErect.hxc
+++ b/preload/scripts/stages/phillyStreetsErect.hxc
@@ -182,6 +182,11 @@ class PhillyStreetsErectStage extends Stage
 
 		colorShader = new AdjustColorShader();
 
+		colorShader.hue = -5;
+		colorShader.saturation = -40;
+		colorShader.contrast = -25;
+		colorShader.brightness = -20;
+
 		mist0 = new FlxBackdrop(Paths.image('phillyStreets/erect/mistMid'), 0x01);
 		mist0.setPosition(-650, -100);
 		mist0.scrollFactor.set(1.2, 1.2);
@@ -497,17 +502,6 @@ class PhillyStreetsErectStage extends Stage
 
 		if(scrollingSky != null) scrollingSky.scrollX -= FlxG.elapsed * 22;
 
-		if(PlayState.instance.currentStage.getBoyfriend() != null && PlayState.instance.currentStage.getBoyfriend().shader == null){
-      PlayState.instance.currentStage.getBoyfriend().shader = colorShader;
-		  PlayState.instance.currentStage.getGirlfriend().shader = colorShader;
-		  PlayState.instance.currentStage.getDad().shader = colorShader;
-
-		  colorShader.hue = -5;
-		  colorShader.saturation = -40;
-		  colorShader.contrast = -25;
-		  colorShader.brightness = -20;
-    }
-
 		// if (rainSndAmbience != null) {
 		// 	rainSndAmbience.volume = Math.min(0.3, remappedIntensityValue * 2);
 		// }
@@ -658,5 +652,7 @@ class PhillyStreetsErectStage extends Stage
 		super.addCharacter(character, charType);
 		// add to the mask so that characters hide puddles
 		// frameBufferMan.copySpriteTo("mask", character, 0x000000);
+		trace('Applied stage shader to ' + character.characterName);
+		character.shader = colorShader;
 	}
 }

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -316,12 +316,12 @@ class PhillyTrainErectStage extends Stage
 		trainSound = new FlxSound().loadEmbedded(Paths.sound('train_passes'));
 
     colorShader = new AdjustColorShader();
+		getNamedProp('train').shader = colorShader;
+
 		colorShader.hue = -26;
 		colorShader.saturation = -16;
 		colorShader.contrast = 0;
 		colorShader.brightness = -5;
-		getNamedProp('train').shader = colorShader;
-
 		FlxG.sound.list.add(trainSound);
 
 		for (i in 0...LIGHT_COUNT)
@@ -394,16 +394,7 @@ class PhillyTrainErectStage extends Stage
 		// Apply the shader automatically to each character as it gets added.
 		super.addCharacter(character, charType);
 		trace('Applied stage shader to ' + character.characterName);
-
-		shader = new AdjustColorShader();
-
-    shader.hue = -26;
-		shader.saturation = -16;
-		shader.contrast = 0;
-		shader.brightness = -5;
-
-		character.shader = shader;
-
+		character.shader = colorShader;
 	}
 
 	function onBeatHit(event:SongTimeScriptEvent):Void


### PR DESCRIPTION
Week 5 Erect's stage has this:

```haxe
override function addCharacter(character:BaseCharacter, charType:CharacterType):Void {
	// Apply the shader automatically to each character as it gets added.
	super.addCharacter(character, charType);
	trace('Applied stage shader to ' + character.characterName);
	character.shader = colorShader;
}
```
This applies the shader when a character is added instead of only BF, GF, and Dad. So pretty much any character type can have the shader.
I updated the remaining stage scripts to apply the shader when the character is added.

I tested the stages and everything works fine.