### PR TITLE
[BUGFIX] Fix scripting errors on Pico's 2hot explosion death

### DIFF
--- a/preload/scripts/characters/pico-playable.hxc
+++ b/preload/scripts/characters/pico-playable.hxc
@@ -198,7 +198,7 @@ class PicoPlayerCharacter extends MultiSparrowCharacter {
 		picoDeathExplosion = new FlxAtlasSprite(this.x - 640, this.y - 340, picoDeathExplosionPath);
     PlayState.instance.subState.add(picoDeathExplosion);
 		picoDeathExplosion.zIndex = 1000;
-    picoDeathExplosion.onAnimationFinish.add(onExplosionFinishAnim);
+    picoDeathExplosion.onAnimationComplete.add(onExplosionFinishAnim);
     picoDeathExplosion.visible = true;
 		this.visible = false;
 
@@ -258,16 +258,17 @@ class PicoPlayerCharacter extends MultiSparrowCharacter {
 		super.onAnimationFrame(name, frameNumber, frameIndex);
 
 		if (name == "firstDeath" && frameNumber == 36 - 1) {
-			deathSpriteRetry.animation.play('idle');
-			deathSpriteRetry.visible = true;
+			if (deathSpriteRetry != null) {
+				deathSpriteRetry.animation.play('idle');
+				deathSpriteRetry.visible = true;
+				deathSpriteRetry.x = this.x + 195;
+				deathSpriteRetry.y = this.y - 70;
+			}
 			GameOverSubState.instance.startDeathMusic(1.0, false);
 			// force the deathloop to play in here, since we are starting the music early it
 			// doesn't check this in gameover substate !
 			// also no animation suffix 🤔
 			GameOverSubState.instance.boyfriend.playAnimation('deathLoop');
-
-			deathSpriteRetry.x = this.x + 195;
-			deathSpriteRetry.y = this.y - 70;
 		}
 
 		if (name == "cock" && frameNumber == 3) {


### PR DESCRIPTION
`PicoPlayerCharacter` was using the wrong callback in `doExplosionDeath()` (`onAnimationFinish` instead of `onAnimationComplete`). Furthermore, there wasn't a check to see if `deathSpriteRetry` wasn't null before accessing it. Which caused a second script error.

Fixes https://github.com/FunkinCrew/Funkin/issues/3182