### PR TITLE
Cheer animation as a Note type

### DIFF
--- a/preload/scripts/characters/bf.hxc
+++ b/preload/scripts/characters/bf.hxc
@@ -3,10 +3,32 @@ import flixel.FlxG;
 import funkin.audio.FunkinSound;
 import funkin.play.character.MultiSparrowCharacter;
 import funkin.play.GameOverSubState;
+import funkin.play.character.CharacterType;
+import funkin.play.PlayState;
 
 class BoyfriendCharacter extends MultiSparrowCharacter {
 	function new() {
 		super('bf');
+	}
+	
+	function onNoteHit(event:HitNoteScriptEvent)
+	{
+		if (event.eventCanceled) {
+			// onNoteHit event was cancelled by the gameplay module.
+			return;
+		}
+
+		if (event.note.noteData.getMustHitNote() && characterType == CharacterType.BF) {
+			// Override the hit note animation.
+			switch(event.note.kind) {
+				case "cheer":
+					holdTimer = 0;
+					this.playAnimation('cheer', true, true);
+					return;
+				default:
+					super.onNoteHit(event);
+			}
+		}
 	}
 
 	override function playAnimation(name:String, restart:Bool, ignoreOther:Bool) {

--- a/preload/scripts/characters/spooky-dark.hxc
+++ b/preload/scripts/characters/spooky-dark.hxc
@@ -43,5 +43,20 @@ class SpookyDarkCharacter extends SparrowCharacter {
 		PlayState.instance.currentStage.add(normalChar);
 		PlayState.instance.currentStage.refresh(); // Apply z-index.
 	}
+	
+	function onNoteHit(event:HitNoteScriptEvent)
+	{
+		super.onNoteHit(event);
+
+		if (!event.note.noteData.getMustHitNote() && characterType == CharacterType.DAD) {
+			// Override the hit note animation.
+			switch(event.note.kind) {
+				case "cheer":
+					holdTimer = 0;
+					this.playAnimation('cheer', true, true);
+					return;
+			}
+		}
+	}
 
 }

--- a/preload/scripts/characters/spooky.hxc
+++ b/preload/scripts/characters/spooky.hxc
@@ -1,0 +1,24 @@
+import funkin.play.character.SparrowCharacter;
+import funkin.play.character.CharacterType;
+import funkin.play.PlayState;
+
+class SpookyCharacter extends SparrowCharacter {
+	function new() {
+		super('spooky');
+	}
+
+	function onNoteHit(event:HitNoteScriptEvent)
+	{
+		super.onNoteHit(event);
+
+		if (!event.note.noteData.getMustHitNote() && characterType == CharacterType.DAD) {
+			// Override the hit note animation.
+			switch(event.note.kind) {
+				case "cheer":
+					holdTimer = 0;
+					this.playAnimation('cheer', true, true);
+					return;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Originally, the cheer animation was the Play Animation event. This pull request shows that the cheer animation should be play as a note type instead of the Play Animation event.

https://github.com/user-attachments/assets/a75fb1d6-6f30-4cd4-a517-157794811946