### PR TITLE
Remove Focus Camera on Boyfriend event at start of Roses

### DIFF
--- a/preload/data/songs/roses/roses-chart.json
+++ b/preload/data/songs/roses/roses-chart.json
@@ -1,6 +1,5 @@
 {
   "events": [
-    { "e": "FocusCamera", "t": 0, "v": { "char": 0 } },
     { "e": "FocusCamera", "t": 500, "v": { "char": 1 } },
     { "e": "FocusCamera", "t": 4500, "v": { "char": 0 } },
     { "e": "FocusCamera", "t": 8000, "v": { "char": 1 } },

--- a/preload/scripts/stages/props/PicoBloodPool.hxc
+++ b/preload/scripts/stages/props/PicoBloodPool.hxc
@@ -10,6 +10,9 @@ import funkin.audio.FunkinSound;
 class PicoBloodPool extends FlxAtlasSprite
 {
 
+  var extend:Bool = false;
+
+  var el = null;
   public function new(x:Float, y:Float)
   {
     super(x, y, Paths.animateAtlas("philly/erect/bloodPool", "week3"), {
@@ -22,6 +25,10 @@ class PicoBloodPool extends FlxAtlasSprite
     });
 
    // onAnimationFinish.add(finishCanAnimation);
+   onAnimationComplete.addOnce((_)->{
+    el = anim.curSymbol.getElement(0);
+    extend = true;
+  });
     this.visible = false;
   }
 
@@ -29,5 +36,23 @@ class PicoBloodPool extends FlxAtlasSprite
     playAnimation("poolAnim", true, false, false);
     //backingTextYeah.anim.play("");
     this.visible = true;
+  }
+
+
+  override public function update(elapsed:Float)
+  {
+    super.update(elapsed);
+    if (extend)
+    {
+      var val = 0.02 * elapsed;
+
+      var mat = el.matrix;
+      mat.a += val;
+      mat.d += val;
+
+      mat.tx -= el.symbol.transformationPoint.x * val;
+      mat.ty -= el.symbol.transformationPoint.y * val;
+    }
+
   }
 }


### PR DESCRIPTION
## Linked Issue
Fixes https://github.com/FunkinCrew/Funkin/issues/3875

## Description
*This issue has been known for a long time, but I don't think anyone's made a PR for it until now.*

The camera doesn't snap strangely at the beginning of Roses anymore.

Note: I didn't inspect the rest of the chart, only removed one event.