### PR TITLE
angry senpai fix

### DIFF
--- a/preload/data/dialogue/boxes/roses.json
+++ b/preload/data/dialogue/boxes/roses.json
@@ -56,7 +56,7 @@
       "name": "angrySenpai",
       "prefix": "SENPAI ANGRY IMPACT SPEECH0",
       "offsets": [0, 0],
-      "frameRate": 24
+      "frameRate": 11
     }
   ]
 }

--- a/preload/data/songs/senpai/senpai-chart.json
+++ b/preload/data/songs/senpai/senpai-chart.json
@@ -27,7 +27,8 @@
     { "t": 73333, "e": "FocusCamera", "v": { "char": 1 } },
     { "t": 76666, "e": "FocusCamera", "v": { "char": 0 } },
     { "t": 80000, "e": "FocusCamera", "v": { "char": 1 } },
-    { "t": 86666, "e": "FocusCamera", "v": { "char": 0 } }
+    { "t": 86666, "e": "FocusCamera", "v": { "char": 0 } },
+    { "t": 96666, "e": "FocusCamera", "v": { "char": 1 } }
   ],
   "notes": {
     "easy": [

--- a/preload/scripts/songs/roses.hxc
+++ b/preload/scripts/songs/roses.hxc
@@ -10,6 +10,7 @@ import flixel.tweens.FlxTween;
 import funkin.save.Save;
 import flixel.tweens.FlxEase;
 import funkin.ui.options.PreferencesMenu;
+import flixel.util.FlxTimer;
 
 class RosesSong extends Song {
   var hasPlayedCutscene:Bool;
@@ -58,13 +59,19 @@ class RosesSong extends Song {
 
       // Play a SFX
       FunkinSound.playOnce(Paths.sound('ANGRY_TEXT_BOX'), 1.0);
+      FunkinSound.playOnce(Paths.sound('ANGRY'), 1.0);
 
       // ERIC: There's a known bug where, on the School stage, pausing the stage animations then trying
       // to restart them causes the animations to freeze.
       // TODO: Commenting out this line causes the animations to work but they play even during the dialogue, which is supposed to pause everything.
       // PlayState.instance.currentStage.pause();
 
-      startDialogue();
+      //So that the bars don't fade in and ruin the moment
+      PlayState.instance.camHUD.visible = false;
+      new FlxTimer().start(2, function(tmr)
+		  {
+			      startDialogue();
+		  });
     }
 	}
 
@@ -120,6 +127,8 @@ class RosesSong extends Song {
   }
 
   public override function onDialogueEnd() {
+    //Ok, we can enable the HUD again
+    PlayState.instance.camHUD.visible = true;
     // We may need to wait for the outro to play.
     Countdown.performCountdown();
   }


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.

## Briefly describe the issue(s) fixed.
The current version of senpai getting angry is sort of broken - it doesn't pan to senpai before the roses song, it doesn't play the angry text sound, the animation of the dialogue box is sped up too fast and the UI kind of distracts from the scene altogether (that, and it plays the dialogue music too???)
## Include any relevant screenshots or videos.
## Previous engine version:
https://github.com/user-attachments/assets/c514fe22-4384-4d72-9e13-e8eb44408963

(video is of psych engine, but it should still be applicable of course)

## Current version
https://github.com/user-attachments/assets/8341cb07-5097-40b1-9954-1c854d5aeb1d

## Fixed version
https://github.com/user-attachments/assets/29a6a840-4cdf-4265-ad5a-99364403122c

This pull request needs to happen with the [no dialogue music crash fix](https://github.com/FunkinCrew/Funkin/pull/4057), otherwise after the conversation finishes, it will crash.
Also, yay, first pull request (and hopefully not the last/only one too?) 