### PR TITLE
weekend1 rain in later songs now starts on stage start fix

### DIFF
--- a/preload/scripts/stages/phillyStreets.hxc
+++ b/preload/scripts/stages/phillyStreets.hxc
@@ -375,7 +375,10 @@ class PhillyStreetsStage extends Stage
 	{
 		super.onUpdate(event);
 
-		var remappedIntensityValue:Float = FlxMath.remapToRange(Conductor.instance.songPosition, 0, FlxG.sound.music != null ? FlxG.sound.music.length : 0.0, rainShaderStartIntensity, rainShaderEndIntensity);
+		var remappedIntensityValue:Float = rainShaderStartIntensity;
+		if (FlxG.sound.music != null) {
+			remappedIntensityValue = FlxMath.remapToRange(Conductor.instance.songPosition > 0 ? Conductor.instance.songPosition : rainShaderStartIntensity, 0, FlxG.sound.music.length, rainShaderStartIntensity, rainShaderEndIntensity);
+		}
 		rainShader.intensity = remappedIntensityValue;
 		rainShader.updateViewInfo(FlxG.width, FlxG.height, FlxG.camera);
 		rainShader.update(event.elapsed);

--- a/preload/scripts/stages/phillyStreetsErect.hxc
+++ b/preload/scripts/stages/phillyStreetsErect.hxc
@@ -480,7 +480,10 @@ class PhillyStreetsErectStage extends Stage
 		// mist5.y = -450 + (Math.sin(_timer*0.2)*1xxx50);
 		//trace(mist1.y);
 
-		var remappedIntensityValue:Float = FlxMath.remapToRange(Conductor.instance.songPosition, 0, FlxG.sound.music != null ? FlxG.sound.music.length : 0.0, rainShaderStartIntensity, rainShaderEndIntensity);
+		var remappedIntensityValue:Float = rainShaderStartIntensity;
+		if (FlxG.sound.music != null) {
+			remappedIntensityValue = FlxMath.remapToRange(Conductor.instance.songPosition > 0 ? Conductor.instance.songPosition : rainShaderStartIntensity, 0, FlxG.sound.music.length, rainShaderStartIntensity, rainShaderEndIntensity);
+		}
 		rainShader.intensity = remappedIntensityValue;
 		rainShader.updateViewInfo(FlxG.width, FlxG.height, FlxG.camera);
 		rainShader.update(event.elapsed);


### PR DESCRIPTION
<!-- Please check for duplicates or similar PRs before submitting this PR. -->
## Does this PR close any issues? If so, link them below.
https://github.com/FunkinCrew/Funkin/issues/4078
## Briefly describe the issue(s) fixed.
In the other 2 songs of weekend 1, the rain doesn't start until the song starts. This fix provides passes the rainShaderStartIntensity for the rain's remappedIntensityValue instead of the songPosition if the it's less than zero.
## Include any relevant screenshots or videos.
### Pre-fix
https://github.com/user-attachments/assets/bf07092c-3ac9-49e4-986f-ed622b135c99
### Post-fix
https://github.com/user-attachments/assets/b6733c7a-b90e-49dc-8e95-05039ae9c8a1

I noticed that AppleHair made a fix for that put the remappedIntensityValue update in a null check, so I've also done the same thing so that it's easier to merge? Idk if that's how it works. 

If I need to make the change from a branch that starts with the community fixes let me know and I'll quickly fix this PR.