### PR TITLE
PR: Changes character positions in the Spooky Mansion stage to be consistent with the remix version/Fixes Monster's offsets

### DIFF
--- a/preload/data/characters/monster.json
+++ b/preload/data/characters/monster.json
@@ -1,75 +1,247 @@
 {
-  "version": "1.0.0",
-  "name": "Monster",
-  "assetPath": "characters/Monster_Assets",
-  "animations": [
-    {
-      "name": "idle",
-      "prefix": "monster idle",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "idle-hold",
-      "prefix": "monster idle",
-      "looped": true,
-      "frameIndices": [11, 12, 13, 14],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singLEFT",
-      "prefix": "Monster Right note",
-      "offsets": [-30, 20]
-    },
-    {
-      "name": "singLEFT-hold",
-      "prefix": "Monster Right note",
-      "looped": true,
-      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-30, 20]
-    },
-    {
-      "name": "singDOWN",
-      "prefix": "monster down",
-      "offsets": [-50, -80]
-    },
-    {
-      "name": "singDOWN-hold",
-      "prefix": "monster down",
-      "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [-50, -80]
-    },
-    {
-      "name": "singUP",
-      "prefix": "monster up note",
-      "offsets": [-20, 94]
-    },
-    {
-      "name": "singUP-hold",
-      "prefix": "monster up note",
-      "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23
-      ],
-      "offsets": [-20, 94]
-    },
-    {
-      "name": "singRIGHT",
-      "prefix": "Monster left note",
-      "offsets": [-51, 30]
-    },
-    {
-      "name": "singRIGHT-hold",
-      "prefix": "Monster left note",
-      "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
-      ],
-      "offsets": [-51, 30]
-    }
-  ]
+	"version": "1.0.0",
+	"renderType": "sparrow",
+	"offsets": [
+		0,
+		0
+	],
+	"danceEvery": 1,
+	"scale": 1,
+	"name": "Monster",
+	"cameraOffsets": [
+		0,
+		0
+	],
+	"flipX": false,
+	"startingAnimation": "idle",
+	"isPixel": false,
+	"singTime": 8,
+	"healthIcon": {
+		"isPixel": false,
+		"offsets": [
+			0,
+			0
+		],
+		"scale": 1,
+		"id": "monster",
+		"flipX": false
+	},
+	"assetPath": "characters/Monster_Assets",
+	"animations": [
+		{
+			"offsets": [
+				0,
+				-20
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"prefix": "monster idle",
+			"name": "idle",
+			"looped": false,
+			"flipX": false
+		},
+		{
+			"offsets": [
+				0,
+				-20
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"frameIndices": [
+				11,
+				12,
+				13,
+				14
+			],
+			"prefix": "monster idle",
+			"looped": true,
+			"name": "idle-hold",
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-30,
+				-10
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"prefix": "Monster Right note",
+			"name": "singLEFT",
+			"looped": false,
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-30,
+				-10
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"frameIndices": [
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14
+			],
+			"prefix": "Monster Right note",
+			"looped": true,
+			"name": "singLEFT-hold",
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-50,
+				-110
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"prefix": "monster down",
+			"name": "singDOWN",
+			"looped": false,
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-50,
+				-110
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"frameIndices": [
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23,
+				24,
+				25,
+				26,
+				27,
+				28,
+				29
+			],
+			"prefix": "monster down",
+			"looped": true,
+			"name": "singDOWN-hold",
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-20,
+				69
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"prefix": "monster up note",
+			"name": "singUP",
+			"looped": false,
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-20,
+				69
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"frameIndices": [
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19,
+				20,
+				21,
+				22,
+				23
+			],
+			"prefix": "monster up note",
+			"looped": true,
+			"name": "singUP-hold",
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-36,
+				-10
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"prefix": "Monster left note",
+			"name": "singRIGHT",
+			"looped": false,
+			"flipX": false
+		},
+		{
+			"offsets": [
+				-36,
+				-10
+			],
+			"flipY": false,
+			"frameRate": 24,
+			"frameIndices": [
+				2,
+				3,
+				4,
+				5,
+				6,
+				7,
+				8,
+				9,
+				10,
+				11,
+				12,
+				13,
+				14,
+				15,
+				16,
+				17,
+				18,
+				19
+			],
+			"prefix": "Monster left note",
+			"looped": true,
+			"name": "singRIGHT-hold",
+			"flipX": false
+		}
+	]
 }

--- a/preload/data/stages/spookyMansion.json
+++ b/preload/data/stages/spookyMansion.json
@@ -45,10 +45,10 @@
   "characters": {
     "bf": {
       "zIndex": 200,
-      "position": [989.5, 885],
-      "cameraOffsets": [-100, -100]
+      "position": [1250, 835],
+      "cameraOffsets": [-320, -100]
     },
-    "gf": { "zIndex": 100, "position": [751.5, 787], "cameraOffsets": [0, 0] },
+    "gf": { "zIndex": 100, "position": [821.5, 800], "cameraOffsets": [0, 0] },
     "dad": {
       "zIndex": 200,
       "position": [382, 831],


### PR DESCRIPTION
I feel this would make the character positions in the stage look less off.

BEFORE:
![Screenshot (475)](https://github.com/user-attachments/assets/d93da8ad-b0ac-4265-bb9e-808715837e61)

AFTER (Remix stage for comparison):
![Screenshot (473)](https://github.com/user-attachments/assets/52a45408-a3d6-49f1-affa-95e243decc31)
![Screenshot (474)](https://github.com/user-attachments/assets/c3eb1e74-0210-4275-8d3e-dd696f3d67bd)

Fixed Monster Offsets:

https://github.com/user-attachments/assets/97861866-02ae-4577-bb5d-015d45389f58

