### PR TITLE
[BUGFIX] Fix Philly Train Erect stage from breaking after Pico cutscene.

### DIFF
--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -50,6 +50,8 @@ class PhillyTrainErectStage extends Stage
 	  canSkipCutscene = false;
 		playerShoots = false;
 		explode = true;
+		cutsceneTimerManager = null;
+		cutsceneConductor = null;
   }
 
 	public override function onCountdownStart(event:CountdownScriptEvent):Void {


### PR DESCRIPTION
Fixes [this issue](https://github.com/FunkinCrew/Funkin/issues/3345) in the Funkin repo. 
This change makes sure that `cutsceneTimerManager` and `cutsceneConductor` are null when the stage loads and they only get set when the Pico doppelganger cutscene is played.