### PR TITLE
[BUGFIX] Fix error when getting fakeout death while testing in Chart Editor

### DIFF
--- a/preload/scripts/characters/bf.hxc
+++ b/preload/scripts/characters/bf.hxc
@@ -23,15 +23,15 @@ class BoyfriendCharacter extends MultiSparrowCharacter {
 		FunkinSound.playOnce(Paths.sound("gameplay/gameover/fakeout_death"), 1.0);
 
 		var bfFakeout:FlxAtlasSprite = new FlxAtlasSprite(this.x - 440, this.y - 240, Paths.animateAtlas("characters/bfFakeOut", "shared"));
-    FlxG.state.subState.add(bfFakeout);
+		GameOverSubState.instance.add(bfFakeout);
 		bfFakeout.zIndex = 1000;
     bfFakeout.playAnimation('');
 		// We don't want people to miss this.
-		FlxG.state.subState.mustNotExit = true;
+		GameOverSubState.instance.mustNotExit = true;
     bfFakeout.onAnimationComplete.add(() -> {
       bfFakeout.visible = false;
       this.visible = true;
-			FlxG.state.subState.mustNotExit = false;
+			GameOverSubState.instance.mustNotExit = false;
       this.playAnimation('firstDeath', true, true);
       // Play the "blue balled" sound. May play a variant if one has been assigned.
       GameOverSubState.playBlueBalledSFX();


### PR DESCRIPTION
## Does this PR fixes/closes any issues?
Fixes https://github.com/FunkinCrew/Funkin/issues/2554

## Briefly describe the issue(s) fixed.
The script would always suppose the current state's substate was the `GameOverSubState` which isn't the case when you're in the chart editor.
This changes it so it gets the game over substate directly from the singleton.