### PR TITLE
hit window offset fix

### DIFF
--- a/preload/data/notestyles/funkin.json
+++ b/preload/data/notestyles/funkin.json
@@ -17,7 +17,7 @@
     "noteStrumline": {
       "assetPath": "shared:noteStrumline",
       "scale": 0.7,
-      "offsets": [0, 0],
+      "offsets": [0, 9],
       "data": {
         "leftStatic": { "prefix": "staticLeft0" },
         "leftPress": { "prefix": "pressLeft0" },
@@ -40,6 +40,7 @@
     "holdNote": {
       "assetPath": "NOTE_hold_assets",
       "scale": 0.7,
+      "offsets": [0, -9],
       "data": {}
     },
     "noteSplash": {

--- a/preload/data/notestyles/funkin.json
+++ b/preload/data/notestyles/funkin.json
@@ -68,7 +68,7 @@
     },
     "holdNoteCover": {
       "assetPath": "",
-      "offsets": [0, 0],
+      "offsets": [0, 9],
       "data": {
         "enabled": true,
         "left": {

--- a/preload/data/notestyles/pixel.json
+++ b/preload/data/notestyles/pixel.json
@@ -83,7 +83,7 @@
       "assetPath": "week6:pixelNoteHoldCover",
       "scale": 6.0,
       "isPixel": true,
-      "offsets": [29, -4],
+      "offsets": [29, -2.5],
       "data": {
         "enabled": true,
         "left": {

--- a/preload/data/notestyles/pixel.json
+++ b/preload/data/notestyles/pixel.json
@@ -18,7 +18,7 @@
     "noteStrumline": {
       "assetPath": "week6:weeb/pixelUI/arrows-pixels",
       "scale": 6.0,
-      "offsets": [28, 32],
+      "offsets": [28, 40],
       "isPixel": true,
       "data": {
         "leftStatic": { "prefix": "staticLeft0" },
@@ -42,7 +42,7 @@
     "holdNote": {
       "assetPath": "week6:weeb/pixelUI/arrowEndsNew",
       "scale": 6.0,
-      "offsets": [2, 1],
+      "offsets": [2, -8],
       "isPixel": true,
       "data": {}
     },

--- a/preload/data/notestyles/pixel.json
+++ b/preload/data/notestyles/pixel.json
@@ -18,7 +18,7 @@
     "noteStrumline": {
       "assetPath": "week6:weeb/pixelUI/arrows-pixels",
       "scale": 6.0,
-      "offsets": [28, 40],
+      "offsets": [28, 30],
       "isPixel": true,
       "data": {
         "leftStatic": { "prefix": "staticLeft0" },
@@ -42,7 +42,7 @@
     "holdNote": {
       "assetPath": "week6:weeb/pixelUI/arrowEndsNew",
       "scale": 6.0,
-      "offsets": [2, -8],
+      "offsets": [2, 4],
       "isPixel": true,
       "data": {}
     },
@@ -83,7 +83,7 @@
       "assetPath": "week6:pixelNoteHoldCover",
       "scale": 6.0,
       "isPixel": true,
-      "offsets": [29, -2.5],
+      "offsets": [29, -4.2],
       "data": {
         "enabled": true,
         "left": {


### PR DESCRIPTION
Fixes FunkinCrew/Funkin#2969, fixes FunkinCrew/Funkin#2400, closes FunkinCrew/Funkin#2877
The hit window appeared to be offset, these new offsets ensure that is no longer the case.