### PR TITLE
Darnell (BF Mix) alternate instrumental check

### DIFF
--- a/preload/scripts/songs/darnell.hxc
+++ b/preload/scripts/songs/darnell.hxc
@@ -43,6 +43,21 @@ class DarnellSong extends Song {
 		return [];
 	}
 
+  public override function listAltInstrumentalIds(difficultyId:String, variationId:String):Array<String> {
+    if (difficultyId == 'easy' || difficultyId == 'normal' || difficultyId == 'hard') {
+      var hasBeatenBFMix = Save.instance.hasBeatenSong(this.id, null, 'darnell');
+
+      switch (variationId) {
+        case 'bf':
+          // return hasBeatenBFMix ? [''] : [];
+          // No BF mix on Pico instrumental, sorry!
+          return [];
+        default:
+          return hasBeatenBFMix ? ['bf'] : [];
+      }
+    }
+  }
+
   public override function onCountdownStart(event:CountdownScriptEvent):Void {
 		super.onCountdownStart(event);
 


### PR DESCRIPTION
Fixes https://github.com/FunkinCrew/Funkin/issues/4329

## Changes
Copies code from other song scripts to check if Darnell (BF Mix) has been beaten.
Locks the BF instrumental on Darnell until the BF Mix is beaten.

## Note
I didn't add the `isNewSong` check because 0.6.0 will be releasing soon.
It should be added to Lit Up (BF Mix) on release, though!