### PR TITLE
Week 1 Erect Stage Camera Fixes

### DIFF
--- a/preload/data/songs/bopeebo/bopeebo-chart-erect.json
+++ b/preload/data/songs/bopeebo/bopeebo-chart-erect.json
@@ -215,7 +215,7 @@
     {
       "t": 78048,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -100, "y": 0, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -100, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 78078,
@@ -235,7 +235,7 @@
     {
       "t": 85853,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 0, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 85883,
@@ -245,7 +245,7 @@
     {
       "t": 92682,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 32, "y": 0, "char": 0, "ease": "expoOut" }
+      "v": { "x": 0, "duration": 32, "y": -40, "char": 0, "ease": "expoOut" }
     },
     {
       "t": 92712,
@@ -265,12 +265,12 @@
     {
       "t": 97560.9756097561,
       "e": "FocusCamera",
-      "v": { "duration": 4, "x": 0, "y": 0, "ease": "CLASSIC", "char": 1 }
+      "v": { "duration": 4, "x": 70, "y": 0, "ease": "CLASSIC", "char": 1 }
     },
     {
       "t": 98780.4878048781,
       "e": "FocusCamera",
-      "v": { "duration": 4, "x": 0, "y": 0, "ease": "CLASSIC", "char": 0 }
+      "v": { "duration": 4, "x": 0, "y": -10, "ease": "CLASSIC", "char": 0 }
     },
     {
       "t": 99512.0975609756,

--- a/preload/data/songs/dadbattle/dadbattle-chart-erect.json
+++ b/preload/data/songs/dadbattle/dadbattle-chart-erect.json
@@ -105,7 +105,7 @@
     {
       "t": 41368,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -100, "y": 30, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -100, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 41398,
@@ -115,7 +115,7 @@
     {
       "t": 45473,
       "e": "FocusCamera",
-      "v": { "x": -20, "duration": 32, "y": 30, "char": 2, "ease": "expoOut" }
+      "v": { "x": -20, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 49263.1578947368,
@@ -156,7 +156,7 @@
     {
       "t": 60631,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 30, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 60661,
@@ -166,22 +166,22 @@
     {
       "t": 63157,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -20, "y": 30, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -20, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 65684,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 30, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 68210,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -20, "y": 30, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -20, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 70736,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -100, "y": 30, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -100, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 75710.5263157895,
@@ -286,7 +286,7 @@
     {
       "t": 111157,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 30, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 111187,

--- a/preload/data/songs/fresh/fresh-chart-erect.json
+++ b/preload/data/songs/fresh/fresh-chart-erect.json
@@ -75,7 +75,7 @@
     {
       "t": 23040,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 0, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 23070,
@@ -85,7 +85,7 @@
     {
       "t": 26880,
       "e": "FocusCamera",
-      "v": { "duration": 16, "x": 0, "y": 0, "ease": "expoOut", "char": 0 }
+      "v": { "duration": 16, "x": 0, "y": -20, "ease": "expoOut", "char": 0 }
     },
     {
       "t": 26940.9512195122,
@@ -100,7 +100,7 @@
     {
       "t": 30720,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -100, "y": 0, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -100, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 30780.9512195122,
@@ -110,7 +110,7 @@
     {
       "t": 34560,
       "e": "FocusCamera",
-      "v": { "duration": 16, "x": 0, "y": 0, "ease": "expoOut", "char": 0 }
+      "v": { "duration": 16, "x": 0, "y": -10, "ease": "expoOut", "char": 0 }
     },
     {
       "t": 34620.9512195122,
@@ -140,17 +140,17 @@
     {
       "t": 38640,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
+      "v": { "x": 90, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
     },
     {
       "t": 40560,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 0 }
+      "v": { "x": 0, "duration": 4, "y": -30, "ease": "CLASSIC", "char": 0 }
     },
     {
       "t": 42480,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
+      "v": { "x": 90, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
     },
     {
       "t": 44160.6341463415,
@@ -175,7 +175,7 @@
     {
       "t": 46080,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
+      "v": { "x": 100, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 1 }
     },
     {
       "t": 46140.9512195122,
@@ -185,7 +185,7 @@
     {
       "t": 49920,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "ease": "CLASSIC", "char": 0 }
+      "v": { "x": 0, "duration": 4, "y": -30, "ease": "CLASSIC", "char": 0 }
     },
     {
       "t": 50880,
@@ -200,7 +200,7 @@
     {
       "t": 54000,
       "e": "FocusCamera",
-      "v": { "duration": 32, "x": -100, "y": 0, "ease": "expoOut", "char": 2 }
+      "v": { "duration": 32, "x": -100, "y": -20, "ease": "expoOut", "char": 2 }
     },
     {
       "t": 54030,
@@ -210,17 +210,17 @@
     {
       "t": 55680,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 32, "y": 0, "char": 0, "ease": "expoOut" }
+      "v": { "x": 0, "duration": 32, "y": -40, "char": 0, "ease": "expoOut" }
     },
     {
       "t": 57840,
       "e": "FocusCamera",
-      "v": { "x": -100, "duration": 32, "y": 0, "char": 2, "ease": "expoOut" }
+      "v": { "x": -100, "duration": 32, "y": -20, "char": 2, "ease": "expoOut" }
     },
     {
       "t": 59520,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 32, "y": 0, "char": 0, "ease": "expoOut" }
+      "v": { "x": 0, "duration": 32, "y": -40, "char": 0, "ease": "expoOut" }
     },
     {
       "t": 61440,

--- a/preload/scripts/stages/props/PicoBloodPool.hxc
+++ b/preload/scripts/stages/props/PicoBloodPool.hxc
@@ -10,6 +10,9 @@ import funkin.audio.FunkinSound;
 class PicoBloodPool extends FlxAtlasSprite
 {
 
+  var extend:Bool = false;
+
+  var el = null;
   public function new(x:Float, y:Float)
   {
     super(x, y, Paths.animateAtlas("philly/erect/bloodPool", "week3"), {
@@ -22,6 +25,10 @@ class PicoBloodPool extends FlxAtlasSprite
     });
 
    // onAnimationFinish.add(finishCanAnimation);
+   onAnimationComplete.addOnce((_)->{
+    el = anim.curSymbol.getElement(0);
+    extend = true;
+  });
     this.visible = false;
   }
 
@@ -29,5 +36,23 @@ class PicoBloodPool extends FlxAtlasSprite
     playAnimation("poolAnim", true, false, false);
     //backingTextYeah.anim.play("");
     this.visible = true;
+  }
+
+
+  override public function update(elapsed:Float)
+  {
+    super.update(elapsed);
+    if (extend)
+    {
+      var val = 0.02 * elapsed;
+
+      var mat = el.matrix;
+      mat.a += val;
+      mat.d += val;
+
+      mat.tx -= el.symbol.transformationPoint.x * val;
+      mat.ty -= el.symbol.transformationPoint.y * val;
+    }
+
   }
 }


### PR DESCRIPTION
Fixes FunkinCrew/Funkin#3242 (The issue says Fresh, but the problem occurs in all Week 1 Erect songs)

I assume these camera events were created in 0.3.0, but weren't changed when the stage for the songs got changed in 0.5.0.

For camera events that showed past the left edge of the screen, I moved them right. For camera events that showed past the bottom edge of the screen, I moved them up (a negative Y value is up).

# Comparison Clips

## Bopeebo

Before:

https://github.com/user-attachments/assets/eb095a34-22dc-4d18-9a2e-60a8fb791eee

After:

https://github.com/user-attachments/assets/20f424d8-586b-448b-a24c-bae6a5440a30

## Fresh

Before:

https://github.com/user-attachments/assets/6e7c72bf-ef01-463f-919d-b14229151224

After:

https://github.com/user-attachments/assets/baa6665c-2d32-4974-b957-796e81ae42cf

## DadBattle

Before:

https://github.com/user-attachments/assets/ee5092dd-3a6a-41a5-b90d-ce688a647020

After:

https://github.com/user-attachments/assets/31ea996a-ab98-47d8-862f-496da6976e27