### PR TITLE
South Erect Stage Camera Fix

### DIFF
--- a/preload/data/songs/south/south-chart-erect.json
+++ b/preload/data/songs/south/south-chart-erect.json
@@ -310,7 +310,7 @@
     {
       "t": 103051.634146342,
       "e": "FocusCamera",
-      "v": { "duration": 4, "x": 0, "y": 0, "ease": "CLASSIC", "char": 0 }
+      "v": { "duration": 4, "x": -60, "y": 0, "ease": "CLASSIC", "char": 0 }
     },
     {
       "t": 103093.951219512,
@@ -335,7 +335,7 @@
     {
       "t": 108474.634146342,
       "e": "FocusCamera",
-      "v": { "x": 0, "duration": 4, "y": 0, "char": 0, "ease": "CLASSIC" }
+      "v": { "x": -60, "duration": 4, "y": 0, "char": 0, "ease": "CLASSIC" }
     },
     {
       "t": 108517.951219512,
@@ -348,7 +348,7 @@
       "v": {
         "duration": 64,
         "ease": "sineInOut",
-        "zoom": 0.75,
+        "zoom": 0.8,
         "mode": "stage"
       }
     }

--- a/preload/scripts/stages/props/PicoBloodPool.hxc
+++ b/preload/scripts/stages/props/PicoBloodPool.hxc
@@ -10,6 +10,9 @@ import funkin.audio.FunkinSound;
 class PicoBloodPool extends FlxAtlasSprite
 {
 
+  var extend:Bool = false;
+
+  var el = null;
   public function new(x:Float, y:Float)
   {
     super(x, y, Paths.animateAtlas("philly/erect/bloodPool", "week3"), {
@@ -22,6 +25,10 @@ class PicoBloodPool extends FlxAtlasSprite
     });
 
    // onAnimationFinish.add(finishCanAnimation);
+   onAnimationComplete.addOnce((_)->{
+    el = anim.curSymbol.getElement(0);
+    extend = true;
+  });
     this.visible = false;
   }
 
@@ -29,5 +36,23 @@ class PicoBloodPool extends FlxAtlasSprite
     playAnimation("poolAnim", true, false, false);
     //backingTextYeah.anim.play("");
     this.visible = true;
+  }
+
+
+  override public function update(elapsed:Float)
+  {
+    super.update(elapsed);
+    if (extend)
+    {
+      var val = 0.02 * elapsed;
+
+      var mat = el.matrix;
+      mat.a += val;
+      mat.d += val;
+
+      mat.tx -= el.symbol.transformationPoint.x * val;
+      mat.ty -= el.symbol.transformationPoint.y * val;
+    }
+
   }
 }


### PR DESCRIPTION
Fixes FunkinCrew/Funkin#3257

At the end of South Erect, the camera zooms out and shows past the right edge of the background. This PR fixes this issue by moving over the two camera events focused on Boyfriend at the end to the left and changing the zoom level of the final zoom event from 0.75 to 0.8.

## Comparison

Before:

https://github.com/user-attachments/assets/6ef6169c-eb29-4b52-8ca4-4eeb97c4dbcb

After:

https://github.com/user-attachments/assets/e8cf9f51-3611-4dd4-8621-eb065f0753fa