### PR TITLE
[FIX] Crash when re-entering Stress song

### DIFF
--- a/preload/scripts/songs/stress.hxc
+++ b/preload/scripts/songs/stress.hxc
@@ -233,6 +233,11 @@ class StressSong extends Song {
     });
 	}
 
+  function onDestroy(event:ScriptEvent):Void {
+    super.onDestroy(event);
+    cleanupTankmanGroup();
+  }
+
   function kill():Void {
     cleanupTankmanGroup();
   }


### PR DESCRIPTION
## RELATED ISSUES
Fixes https://github.com/FunkinCrew/Funkin/issues/4613

## DESCRIPTION
this pr calls the **cleanupTankmanGroup** function inside onDestroy as well to make sure that **tankmanGroup** is set to null, when we exit the song.