### PR TITLE
[ENHANCEMENT]: Pico Pixel Character Name Fix

### DIFF
--- a/preload/data/characters/pico-pixel.json
+++ b/preload/data/characters/pico-pixel.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Pico (Playable)",
+  "name": "Pico (Pixel)",
   "assetPath": "characters/picoPixel/picoPixel",
   "healthIcon": {
     "id": "pico-pixel",


### PR DESCRIPTION
# P.R Issue & Summary:

In the chart editor, when selecting Pico as his playable pixel variant, his name does not correspond with the other Pico variants.
In summary, this pull request makes the `pico-pixel` character have it’s name be consistent with the other Pico variants.

# Images:

## Before:
![theres a fire in our soul](https://github.com/user-attachments/assets/4b29a4d6-91d0-4aa4-9dc8-40374a3fe6da)

## After:
![we are young](https://github.com/user-attachments/assets/ac9b63cb-4968-4403-a4a1-a9088ea90a90)

