### PR TITLE
[FIX] Fix Death Before Senpai Dialogue

### DIFF
--- a/preload/scripts/songs/senpai.hxc
+++ b/preload/scripts/songs/senpai.hxc
@@ -50,6 +50,8 @@ class SenpaiSong extends Song {
   function transitionToDialogue() {
     trace('Transitioning to dialogue.');
 
+    PlayState.instance.disableKeys = true;
+
     PlayState.instance.camCutscene.visible = true;
 
     var black:FlxSprite = new FunkinSprite(-20, -20).makeSolidColor(FlxG.width * 1.5, FlxG.height * 1.5, 0xFF000000);
@@ -79,6 +81,7 @@ class SenpaiSong extends Song {
   }
 
   function startDialogue() {
+    PlayState.instance.disableKeys = false;
     var targetDialogue = PlayState.instance.currentVariation == 'pico' ? 'senpai-pico' : 'senpai';
     PlayState.instance.startConversation(targetDialogue);
   }


### PR DESCRIPTION
## What issues does this PR fix?
* As seen in https://github.com/FunkinCrew/Funkin/issues/4767 and https://github.com/FunkinCrew/Funkin/issues/4477, there is an issue that you are able to spam buttons (including the `RESET` key) before the dialogue starts, which bugs out the game. However, with this PR, with just two simple lines of code, this issue is fixed.