### PR TITLE
Alternate Instrumentals impact Pico/Otis Speaker Animations.

### DIFF
--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -143,16 +143,20 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
     shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
-    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentVariation);
+    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentInstrumental);
     if (animChart == null)
     {
-      trace('Initializing Otis (speaker) failed; no `picospeaker` chart found for this song.');
-      return;
+      trace('Initializing Otis (speaker) failed; no `picospeaker` chart found for this variation.');
+      animChart = PlayState.instance.currentSong.getDifficulty('picospeaker');
+      if (animChart == null)
+      {
+        trace('Initializing Otis (speaker) failed; no `picospeaker` chart found for this song.');
+        return;
+      }
     }
-    else
-    {
-      trace('Initializing Otis (speaker); found `picospeaker` chart, continuing...');
-    }
+
+    trace('Initializing Otis (speaker); found `picospeaker` chart, continuing...');
+
     var animNotes:Array<SongNoteData> = animChart.notes;
 
     // turns out sorting functions are completely useless in polymod right now and do nothing

--- a/preload/scripts/characters/pico-speaker.hxc
+++ b/preload/scripts/characters/pico-speaker.hxc
@@ -52,16 +52,20 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
     shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
-    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker');
+    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentInstrumental);
     if (animChart == null)
     {
-      trace('Initializing Pico (speaker) failed; no `picospeaker` chart found for this song.');
-      return;
+      trace('Initializing Pico (speaker) failed; no `picospeaker` chart found for this variation.');
+      animChart = PlayState.instance.currentSong.getDifficulty('picospeaker');
+      if (animChart == null)
+      {
+        trace('Initializing Pico (speaker) failed; no `picospeaker` chart found for this song.');
+        return;
+      }
     }
-    else
-    {
-      trace('Initializing Pico (speaker); found `picospeaker` chart, continuing...');
-    }
+
+    trace('Initializing Pico (speaker); found `picospeaker` chart, continuing...');
+
     var animNotes:Array<SongNoteData> = animChart.notes;
 
     // turns out sorting functions are completely useless in polymod right now and do nothing

--- a/preload/scripts/stages/props/TankmanSpriteGroup.hxc
+++ b/preload/scripts/stages/props/TankmanSpriteGroup.hxc
@@ -49,16 +49,20 @@ class TankmanSpriteGroup extends FlxTypedSpriteGroup
     tankmanTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
-    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentVariation);
+    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentInstrumental);
     if (animChart == null)
     {
-      trace('Skip initializing TankmanSpriteGroup: no picospeaker chart.');
-      return;
+      trace('TankmanSpriteGroup failed: no picospeaker chart for this variation.');
+      animChart = PlayState.instance.currentSong.getDifficulty('picospeaker');
+      if (animChart == null)
+      {
+        trace('Skip initializing TankmanSpriteGroup: no picospeaker chart.');
+        return;
+      }
     }
-    else
-    {
-      trace('Found picospeaker chart for TankmanSpriteGroup.');
-    }
+
+    trace('Found picospeaker chart for TankmanSpriteGroup.');
+
     var animNotes:Array<SongNoteData> = animChart.notes;
 
     // turns out sorting functions are completely useless in polymod right now and do nothing


### PR DESCRIPTION
Usually, when choosing an alternate instrumental in Stress, Pico's animations are not changed in any way, which means that they are not in-sync with the drums anymore. This PR makes it so changing the instrumental does affect Pico's animations.