### PR TITLE
Properly check for Darnell (BF Mix) alternate instrumental

### DIFF
--- a/preload/scripts/songs/darnell.hxc
+++ b/preload/scripts/songs/darnell.hxc
@@ -43,23 +43,6 @@ class DarnellSong extends Song {
     return false;
 	}
 
-  public override function listAltInstrumentalIds(difficultyId:String, variationId:String):Array<String> {
-    if (difficultyId == 'easy' || difficultyId == 'normal' || difficultyId == 'hard') {
-      var hasBeatenPicoMix = Save.instance.hasBeatenSong(this.id, null, 'pico');
-
-      switch (variationId) {
-        case 'pico':
-          // return hasBeatenPicoMix ? [''] : [];
-          // No Pico mix on BF instrumental, sorry!
-          return [];
-        default:
-          return hasBeatenPicoMix ? ['pico'] : [];
-      }
-    }
-
-    return [];
-  }
-
 	public function listDifficulties(variationId:String, variationIds:Array<String>, showLocked:Bool):Array<String> {
 		if (showLocked || Save.instance.hasBeatenLevel('weekend1')) {
 			return super.listDifficulties(variationId, variationIds);
@@ -68,6 +51,21 @@ class DarnellSong extends Song {
 		// Hide all difficulties if the player has not beaten the week.
 		return [];
 	}
+
+  public override function listAltInstrumentalIds(difficultyId:String, variationId:String):Array<String> {
+    if (difficultyId == 'easy' || difficultyId == 'normal' || difficultyId == 'hard') {
+      var hasBeatenBFMix = Save.instance.hasBeatenSong(this.id, null, 'bf');
+
+      switch (variationId) {
+        case 'bf':
+          // return hasBeatenBFMix ? [''] : [];
+          // No BF mix on Pico instrumental, sorry!
+          return [];
+        default:
+          return hasBeatenBFMix ? ['bf'] : [];
+      }
+    }
+  }
 
   public override function onCountdownStart(event:CountdownScriptEvent):Void {
 		super.onCountdownStart(event);


### PR DESCRIPTION
## Linked Issue
Fixes https://github.com/FunkinCrew/Funkin/issues/4813

## Changes
* Replaces instances of 'pico' with 'bf' in the function `listAltInstrumentalIds` in `darnell.hxc`
* This makes the game check if Darnell (BF Mix) is beaten, not Darnell (Pico Mix)