### PR TITLE
Fix scared animation from lightning strikes preventing forced song event animations from playing

### DIFF
--- a/preload/scripts/stages/spookyMansion.hxc
+++ b/preload/scripts/stages/spookyMansion.hxc
@@ -1,5 +1,7 @@
 import flixel.FlxG;
+import funkin.Conductor;
 import funkin.audio.FunkinSound;
+import funkin.data.event.SongEventRegistry;
 import funkin.play.PlayState;
 import funkin.play.stage.Stage;
 import funkin.util.Constants;
@@ -14,6 +16,25 @@ class SpookyMansionStage extends Stage
 
   var lightningStrikeBeat:Int = 0;
   var lightningStrikeOffset:Int = 8;
+  var bfAnimations = [];
+
+  function onSongLoaded(scriptEvent:SongLoadScriptEvent)
+  {
+    super.onSongLoaded(scriptEvent);
+    var songEvents = scriptEvent.events;
+
+    for (event in songEvents)
+    {
+      if (event.eventKind == "PlayAnimation")
+      {
+        var eventProps = event.value;
+        if ((eventProps.target == "boyfriend" || eventProps.target == "bf") && eventProps.force)
+        {
+          bfAnimations.push(event);
+        }
+      }
+    }
+  }
 
   function doLightningStrike(playSound:Bool, beat:Int):Void
   {
@@ -25,9 +46,14 @@ class SpookyMansionStage extends Stage
     getNamedProp('halloweenBG').animation.play('lightning');
 
     lightningStrikeBeat = beat;
+    var lightningStrikeMs = Conductor.instance.getBeatTimeInMs(lightningStrikeBeat);
     lightningStrikeOffset = FlxG.random.int(8, 24);
 
-    if (getBoyfriend() != null && getBoyfriend().hasAnimation('scared') && getBoyfriend().animation.name != 'cheer')
+    var bfAnimationsToPlay = SongEventRegistry.queryEvents(bfAnimations, lightningStrikeMs);
+    var bfHasAnimationToPlay:Bool = false;
+    if (bfAnimationsToPlay.length > 0) bfHasAnimationToPlay = true;
+
+    if (getBoyfriend() != null && getBoyfriend().hasAnimation('scared') && !bfHasAnimationToPlay)
     {
       getBoyfriend().playAnimation('scared', true, true);
     }

--- a/preload/scripts/stages/spookyMansionErect.hxc
+++ b/preload/scripts/stages/spookyMansionErect.hxc
@@ -1,5 +1,7 @@
 import flixel.FlxG;
+import funkin.Conductor;
 import funkin.audio.FunkinSound;
+import funkin.data.event.SongEventRegistry;
 import funkin.play.PlayState;
 import funkin.play.stage.Stage;
 import flixel.tweens.FlxEase;
@@ -26,6 +28,7 @@ class SpookyMansionErectStage extends Stage
 
   var lightningStrikeBeat:Int = 0;
   var lightningStrikeOffset:Int = 8;
+  var bfAnimations = [];
 
   override function onCreate(event:ScriptEvent):Void
   {
@@ -46,6 +49,24 @@ class SpookyMansionErectStage extends Stage
   function onBranchFrame(name, frameNum, frameIndex)
   {
     rainShader.updateFrameInfo(rainShaderTarget.frame);
+  }
+
+  function onSongLoaded(scriptEvent:SongLoadScriptEvent)
+  {
+    super.onSongLoaded(scriptEvent);
+    var songEvents = scriptEvent.events;
+
+    for (event in songEvents)
+    {
+      if (event.eventKind == "PlayAnimation")
+      {
+        var eventProps = event.value;
+        if ((eventProps.target == "boyfriend" || eventProps.target == "bf") && eventProps.force)
+        {
+          bfAnimations.push(event);
+        }
+      }
+    }
   }
 
   override function buildStage()
@@ -99,9 +120,14 @@ class SpookyMansionErectStage extends Stage
     });
 
     lightningStrikeBeat = beat;
+    var lightningStrikeMs = Conductor.instance.getBeatTimeInMs(lightningStrikeBeat);
     lightningStrikeOffset = FlxG.random.int(8, 24);
 
-    if (getBoyfriend().hasAnimation('scared') && getBoyfriend().animation.name != 'cheer')
+    var bfAnimationsToPlay = SongEventRegistry.queryEvents(bfAnimations, lightningStrikeMs);
+    var bfHasAnimationToPlay:Bool = false;
+    if (bfAnimationsToPlay.length > 0) bfHasAnimationToPlay = true;
+
+    if (getBoyfriend().hasAnimation('scared') && !bfHasAnimationToPlay)
     {
       getBoyfriend().playAnimation('scared', true, true);
     }


### PR DESCRIPTION
Fixes FunkinCrew/Funkin#4376

It seems that Kade attempted to fix this issue in [this commit](https://github.com/FunkinCrew/funkin.assets/commit/725ab30be24ceee990d42887edeef7af7c45642a), but this change doesn't work if the lightning strike happens to occur on the same beat that Boyfriend plays the cheer animation. In fact, even without this change, the cheer animation works correctly if the lightning strike happens on the beat directly before or after the animation. The issue only occurs if they happen on the same beat.

The change from the aforementioned commit doesn't work because the stage script is processed before song events from the chart data. This means that Boyfriend hasn't tried to play the cheer animation yet, so `getBoyfriend().animation.name != 'cheer'` won't work to prevent this.

This PR fixes the issue by getting all forced `PlayAnimation` events which target boyfriend. Then when a lightning strike happens, the script checks whether any of these events happen on the current beat. If there is an event that should play on the current beat, this means that the boyfriend character has a forced animation to play, so they won't play the scared animation.

## Video Comparison

Here is a video of a lighting strike playing on the exact same beat as the cheer animation before the change from this PR:

https://github.com/user-attachments/assets/1c2ec78b-e263-41bc-b9a3-321135bab48e

Here is a video of the same after the change from this PR:

https://github.com/user-attachments/assets/bf472543-7bb9-48e7-9147-4b768b43dfed