### PR TITLE
<PR Recovery> Fix MtH not being credited in Monster's metadata

### DIFF
--- a/preload/data/songs/monster/monster-metadata.json
+++ b/preload/data/songs/monster/monster-metadata.json
@@ -2,7 +2,7 @@
   "version": "2.2.4",
   "songName": "Monster",
   "artist": "BassetFilms",
-  "charter": "ChaoticGamerCG + Spazkid",
+  "charter": "ChaoticGamerCG + MtH + Spazkid",
   "playData": {
     "difficulties": ["easy", "normal", "hard"],
     "characters": { "player": "bf", "girlfriend": "gf", "opponent": "monster" },


### PR DESCRIPTION
Part of an effort to recover 10 merged but lost PRs in funkin.assets

See https://github.com/FunkinCrew/funkin.assets/pull/66 for the original PR