### PR TITLE
Remove Trace Call for Pico's animations

### DIFF
--- a/preload/scripts/characters/pico-playable.hxc
+++ b/preload/scripts/characters/pico-playable.hxc
@@ -268,8 +268,6 @@ class PicoPlayerCharacter extends MultiSparrowCharacter {
 	function onAnimationFrame(name:String, frameNumber:Int, frameIndex:Int) {
 		super.onAnimationFrame(name, frameNumber, frameIndex);
 
-		trace('onAnimationFrame: ' + name + ' ' + frameNumber + ' ' + frameIndex);
-
 		if (name == "firstDeath" && frameNumber == 36 - 1) {
 			if (deathSpriteRetry != null && deathSpriteRetry.animation != null)
 			{


### PR DESCRIPTION
Please don't flood my console with messages of Pico's idle animation:

![Screenshot 2025-04-29 214423](https://github.com/user-attachments/assets/91937b16-08cd-442d-b6e3-2b76310e1a4d)