### PR TITLE
[BUGFIX] Add a missing control tip on Animation Editor

### DIFF
--- a/preload/data/ui/animation-editor/offset-editor-view.xml
+++ b/preload/data/ui/animation-editor/offset-editor-view.xml
@@ -34,6 +34,7 @@
                 <label text="SPACE: Play idle Animation" />
                 <label text="WASD: Play sing Animation" />
                 <label text="F: Toggle Onion Skin" />
+                <label text="G: Flip Character Horizontally" />
                 <label text="ARROWS: Nudge Offsets by 5" />
                 <label text="SHIFT+ARROWS: Nudge Offsets by 10" />
                 <label text="CTRL+ARROWS: Nudge Offsets by 1" />


### PR DESCRIPTION
# Does this PR close any issues? If so, link them below.
One of the bugs reported in https://github.com/FunkinCrew/Funkin/issues/4834

# Briefly describe the issue(s) fixed.
Add a missing control tip for the "Animation" section in "Animation Editor".
The missing tip is the one related to "Flipping the character horizontally" with "G".

# Include any relevant screenshots or videos.
![image](https://github.com/user-attachments/assets/a3230b6e-6cfa-4620-8cf9-01a9af109571)


