### PR TITLE
[BUGFIX] Fix the A-bot visualizer jumping in volume when the song ends

### DIFF
--- a/preload/scripts/characters/nene-christmas.hxc
+++ b/preload/scripts/characters/nene-christmas.hxc
@@ -268,6 +268,12 @@ class NeneChristmasCharacter extends SparrowCharacter {
 		abotViz.dumpSound();
 	}
 
+	override function onSongEnd(event:ScriptEvent)
+	{
+		super.onSongEnd();
+		abotViz.dumpSound();
+	}
+
 	var animationFinished:Bool = false;
 
 	function onAnimationFinished(name:String) {

--- a/preload/scripts/characters/nene-dark.hxc
+++ b/preload/scripts/characters/nene-dark.hxc
@@ -360,6 +360,12 @@ class NeneDarkCharacter extends SparrowCharacter {
 		abotViz.dumpSound();
 	}
 
+	override function onSongEnd(event:ScriptEvent)
+	{
+		super.onSongEnd();
+		abotViz.dumpSound();
+	}
+
 	var animationFinished:Bool = false;
 
 	function onAnimationFinished(name:String) {

--- a/preload/scripts/characters/nene-pixel.hxc
+++ b/preload/scripts/characters/nene-pixel.hxc
@@ -321,6 +321,12 @@ class NenePixelCharacter extends SparrowCharacter {
 		abotViz.dumpSound();
 	}
 
+	override function onSongEnd(event:ScriptEvent)
+	{
+		super.onSongEnd();
+		abotViz.dumpSound();
+	}
+
 	var animationFinished:Bool = false;
 
 	function onAnimationFinished(name:String) {

--- a/preload/scripts/characters/nene.hxc
+++ b/preload/scripts/characters/nene.hxc
@@ -354,6 +354,12 @@ class NeneCharacter extends MultiSparrowCharacter {
 		abotViz.dumpSound();
 	}
 
+	override function onSongEnd(event:ScriptEvent)
+	{
+		super.onSongEnd();
+		abotViz.dumpSound();
+	}
+
 	var animationFinished:Bool = false;
 
 	function onAnimationFinished(name:String) {

--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -264,6 +264,12 @@ class OtisSpeakerCharacter extends SparrowCharacter {
 		abotViz.dumpSound();
 	}
 
+	override function onSongEnd(event:ScriptEvent)
+	{
+		super.onSongEnd();
+		abotViz.dumpSound();
+	}
+
 	function playPicoAnimation(direction:Int):Void
   {
 		muzzleFlash.blend = 0;


### PR DESCRIPTION
Fixes FunkinCrew/Funkin#4941

I'm not sure why the A-bot is reacting to the start of the song when it ends, but the easiest solution would be to just dump the sound when the song ends.


Videos of the visualizer not jumping in volume when the song ends:

https://github.com/user-attachments/assets/8a9c82e7-5c43-4a33-a0b4-644594612720

https://github.com/user-attachments/assets/4f8bcc50-e16a-44db-bd67-979612049d7f

https://github.com/user-attachments/assets/c47f1096-74a7-4a98-9a7d-0ba7981cb150