### PR TITLE
[GITHUB] Add PR labeler actions

### DIFF
--- a/.github/changed-lines-count-labeler.yml
+++ b/.github/changed-lines-count-labeler.yml
@@ -1,0 +1,12 @@
+# Add 'size: small' to any changes below 10 lines
+'size: small':
+  max: 9
+
+# Add 'size: medium' to any changes between 10 and 100 lines
+'size: medium':
+  min: 10
+  max: 99
+
+# Add 'size: large' to any changes of at least 100 lines
+'size: large':
+  min: 100

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,56 @@
+# Configuration for Label Actions - https://github.com/dessant/label-actions
+
+# Automatically close pull requests when the `status: duplicate` label is applied
+'status: duplicate':
+  prs:
+    # Post a comment
+    comment: >
+      This pull request is a duplicate. Please direct all discussion to the original pull request.
+    # Close the pull request
+    close: true
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: needs clarification'
+      - 'status: needs r&d'
+      - 'status: needs revision'
+      - 'status: pending triage'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: resolved internally'
+      - 'status: reviewing internally'
+      - 'status: stale'
+
+'status: stale':
+  prs:
+    # Close the pull request
+    close: true
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs r&d'
+      - 'status: needs revision'
+      - 'status: pending triage'
+      - 'status: rejected'
+      - 'status: resolved'
+      - 'status: resolved internally'
+      - 'status: reviewing internally'
+
+'status: rejected':
+  prs:
+    # Close the pull request
+    close: true
+    # Remove other status labels
+    unlabel:
+      - 'status: accepted'
+      - 'status: duplicate'
+      - 'status: needs clarification'
+      - 'status: needs r&d'
+      - 'status: needs revision'
+      - 'status: pending triage'
+      - 'status: resolved'
+      - 'status: resolved internally'
+      - 'status: reviewing internally'
+      - 'status: stale'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+# Add Documentation tag to PR's changing markdown files, or anything in the docs folder
+'pr: documentation':
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'
+
+# Add HScript tag to PR's changing hscript files
+'pr: hscript':
+- changed-files:
+  - any-glob-to-any-file: '**/*.hxc'
+
+# Add Chart tag to PR's changing chart files
+'pr: chart':
+- changed-files:
+  - any-glob-to-any-file: 'preload/data/songs/**'
+
+# Add Audio tag to PR's changing audio files
+'pr: audio':
+- changed-files:
+  - any-glob-to-any-file:
+    - '**/*.mp3'
+    - '**/*.ogg'
+
+# Add Art tag to PR's changing image or animation files
+'pr: art':
+- changed-files:
+  - any-glob-to-any-file:
+    - 'preload/images/**'
+    - 'shared/images/**'
+    - '**/*.png'
+
+# Add GitHub tag to PR's changing yml files, or anything in the .github folder 
+'pr: github':
+- changed-files:
+  - any-glob-to-any-file:
+    - '.github/**'
+    - '**/*.yml'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
+
+<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
+## Associated Funkin PR
+
+<!-- Does this PR close any issues? If so, link them below. -->
+## Linked Issues
+
+<!-- Briefly describe the issue(s) fixed. -->
+## Description
+
+<!-- Include any relevant screenshots or videos. -->
+## Screenshots/Videos

--- a/.github/workflows/cancel-merged-branches.yml
+++ b/.github/workflows/cancel-merged-branches.yml
@@ -1,0 +1,38 @@
+name: Cancel queued workflows on PR merge
+
+on:
+  pull_request:
+    types:
+    - closed
+
+jobs:
+
+  cancel_stuff:
+    if: github.event.pull_request.merged == true
+    runs-on: build-set
+    permissions:
+      actions: write
+
+    steps:
+    - name: Cancel queued workflows for ${{ github.event.pull_request.head.ref }}
+      uses: actions/github-script@v7
+      with:
+        result-encoding: string
+        retries: 3
+        script: |
+          let branch_workflows = await github.rest.actions.listWorkflowRuns({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            workflow_id: "build-shit.yml",
+            status: "queued",
+            branch: "${{ github.event.pull_request.head.ref }}"
+          });
+          let runs = branch_workflows.data.workflow_runs;
+          runs.forEach((run) => {
+            github.rest.actions.cancelWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: run.id
+            });
+          });
+          console.log(runs);

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,29 @@
+# Perform actions when labels are applied to issues, discussions, or pull requests
+# See .github/label-actions.yml
+name: 'Label Actions'
+
+on:
+  issues:
+    types:
+      - labeled
+      - unlabeled
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+  discussion:
+    types:
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v4

--- a/.github/workflows/label-pull-request-on-create.yml
+++ b/.github/workflows/label-pull-request-on-create.yml
@@ -1,0 +1,19 @@
+name: "Pull Request Labeler 2 (Runs on PR creation)"
+on:
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  # Apply `status: pending triage` to newly created pull requests
+  apply-pending-triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply "status pending triage" to new pull requests
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: "status: pending triage"

--- a/.github/workflows/label-pull-request.yml
+++ b/.github/workflows/label-pull-request.yml
@@ -1,0 +1,29 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  # Apply labels to pull requests based on which files were edited
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set basic labels
+      uses: actions/labeler@v5
+      with:
+        sync-labels: true
+  # Apply labels to pull requests based on how many lines were edited
+  changed-lines-count-labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: An action for automatically labelling pull requests based on the changed lines count
+    steps:
+    - name: Set change count labels
+      uses: vkirilichev/changed-lines-count-labeler@v0.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        configuration-path: .github/changed-lines-count-labeler.yml


### PR DESCRIPTION
## Changes
* Adds the labeler workflows from the main repo, including all 6 `pr: ` labels
* Also includes a PR template