### PR TITLE
Expanded Time Signatures & Time Changes in-editor.

### DIFF
--- a/exclude/data/ui/chart-editor/toolboxes/metadata.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/metadata.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="600" height="490">
+<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="600" height="460">
     <hbox width="100%" height="100%">
         <vbox width="50%" height="100%">
             <frame text="Variation: Default" width="100%" height="70%" id="frameVariation">
                 <grid columns="2" height="100%">
-                    <label text="Song ID:" verticalAlign="center" horizontalAlign="right" />
-                    <textfield id="inputSongId" value="bopeebo" tooltip="The unique identifier for the song. This is used to refer to the song in code/assets and should only contain filename-safe characters." />
                     <label text="Song Name:" verticalAlign="center" horizontalAlign="right" />
                     <textfield id="inputSongName" value="Bopeebo" tooltip="The readable name of the song." />
                     <label text="Song Artist:" verticalAlign="center" horizontalAlign="right" />
@@ -35,18 +33,18 @@
                             <item text="Pixel" />
                         </data>
                     </dropdown>
-                    <hbox width="100%" horizontalAlign="center">
-                        <button id="buttonCharacterOpponent" width="70" height="70" padding="8" iconPosition="top">
-                            Daddy Dearest
-                        </button>
-                        <button id="buttonCharacterGirlfriend" width="70" height="70" padding="8" iconPosition="top">
-                            Girlfriend
-                        </button>
-                        <button id="buttonCharacterPlayer" width="70" height="70" padding="8" iconPosition="top">
-                            Boyfriend
-                        </button>
-                    </hbox>
                 </grid>
+                <hbox width="100%" horizontalAlign="center" verticalAlign="bottom">
+                    <button id="buttonCharacterOpponent" width="70" height="70" padding="8" iconPosition="top">
+                        Daddy Dearest
+                    </button>
+                    <button id="buttonCharacterGirlfriend" width="70" height="70" padding="8" iconPosition="top">
+                        Girlfriend
+                    </button>
+                    <button id="buttonCharacterPlayer" width="70" height="70" padding="8" iconPosition="top">
+                        Boyfriend
+                    </button>
+                </hbox>
             </frame>
             <frame text="Difficulty: Normal" width="100%" height="30%" id="frameDifficulty">
                 <grid columns="2">
@@ -60,14 +58,21 @@
             </frame>
         </vbox>
         <vbox width="50%" height="100%">
+            <dropdown id="inputTimeChange" value="Time Change" width="100%" horizontalAlign="right" dropdownSize="10" dropdownWidth="300" tooltip="The currently selected time change.">
+                <data>
+                    <item text="0 : BPM: 100 in 4/4" />
+                </data>
+            </dropdown> <!--Placing this in the frame after the grid causes it to overlap, idk. Looks cooler here anyway. -->
             <frame text="Timing Data" width="100%" id="frameTiming">
                 <grid columns="2">
-                    <label text="Starting BPM:" verticalAlign="center" />
-                    <number-stepper id="inputBPM" pos="100" step="0.1" min="10" max="500" precision="1" horizontalAlign="right" width="100" tooltip="Adjust the BPM of the song, which helps align the grid and character animations to the music." />
-                    <label text="Starting Time Signature" verticalAlign="center" />
+                    <label text="BPM:" verticalAlign="center" />
+                    <number-stepper id="inputBPM" pos="100" step="1" min="10" max="500" precision="3" horizontalAlign="right" width="160" tooltip="Adjust the BPM of the song, which helps align the grid and character animations to the music." />
+                    <label id="labelTimeStamp" text="Timestamp:" verticalAlign="center" />
+                    <number-stepper id="inputTimeStamp" pos="100" step="150" precision="4" horizontalAlign="right" width="160" tooltip="Adjust the timestamp of when the currently selected time change will start occurring in the song." />
+                    <label text="Time Signature" verticalAlign="center" />
                     <spacer />
                     <label text="Numerator:" verticalAlign="center" />
-                    <dropdown id="inputTSNum" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature numerator of the song, which helps align the grid.">
+                    <dropdown id="inputTSNum" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature numerator of the currently selected time change, which helps align the grid.">
                         <data>
                             <item text="1" />
                             <item text="2" />
@@ -85,10 +90,26 @@
                             <item text="14" />
                             <item text="15" />
                             <item text="16" />
+                            <item text="17" />
+                            <item text="18" />
+                            <item text="19" />
+                            <item text="20" />
+                            <item text="21" />
+                            <item text="22" />
+                            <item text="23" />
+                            <item text="24" />
+                            <item text="25" />
+                            <item text="26" />
+                            <item text="27" />
+                            <item text="28" />
+                            <item text="29" />
+                            <item text="30" />
+                            <item text="31" />
+                            <item text="32" />
                         </data>
                     </dropdown>
                     <label text="Denominator:" verticalAlign="center" />
-                    <dropdown id="inputTSDen" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature denominator of the song, which helps align the grid.">
+                    <dropdown id="inputTSDen" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature denominator of the currently selected time change, which helps align the grid.">
                         <data>
                             <item text="2" />
                             <item text="4" />
@@ -98,6 +119,9 @@
                     </dropdown>
                 </grid>
             </frame>
+            <button allowFocus="false" id="addTimeChange" text="Add Time Change" tooltip="Add a time change after the currently selected time change." />
+            <spacer />
+            <button allowFocus="false" id="removeTimeChange" text="Remove Current Time Change" tooltip="Remove the currently selected time change." />
         </vbox>
     </hbox>
 </collapsible-dialog>

--- a/exclude/data/ui/chart-editor/toolboxes/metadata.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/metadata.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="600" height="460">
+<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="600" height="500">
     <hbox width="100%" height="100%">
         <vbox width="50%" height="100%">
             <frame text="Variation: Default" width="100%" height="70%" id="frameVariation">
                 <grid columns="2" height="100%">
+                    <label text="Song ID:" verticalAlign="center" horizontalAlign="right" />
+                    <textfield id="inputSongId" value="bopeebo" tooltip="The unique identifier for the song. This is used to refer to the song in code/assets and should only contain filename-safe characters." />
                     <label text="Song Name:" verticalAlign="center" horizontalAlign="right" />
                     <textfield id="inputSongName" value="Bopeebo" tooltip="The readable name of the song." />
                     <label text="Song Artist:" verticalAlign="center" horizontalAlign="right" />

--- a/exclude/data/ui/chart-editor/toolboxes/metadata.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/metadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="345" height="522">
-    <vbox width="100%" height="100%">
-        <frame text="Variation: Default" width="100%" height="280" id="frameVariation">
-            <vbox width="100%" height="100%">
+<collapsible-dialog id="toolboxMetadata" title="Song Metadata" width="600" height="490">
+    <hbox width="100%" height="100%">
+        <vbox width="50%" height="100%">
+            <frame text="Variation: Default" width="100%" height="70%" id="frameVariation">
                 <grid columns="2" height="100%">
                     <label text="Song ID:" verticalAlign="center" horizontalAlign="right" />
                     <textfield id="inputSongId" value="bopeebo" tooltip="The unique identifier for the song. This is used to refer to the song in code/assets and should only contain filename-safe characters." />
@@ -35,46 +35,69 @@
                             <item text="Pixel" />
                         </data>
                     </dropdown>
+                    <hbox width="100%" horizontalAlign="center">
+                        <button id="buttonCharacterOpponent" width="70" height="70" padding="8" iconPosition="top">
+                            Daddy Dearest
+                        </button>
+                        <button id="buttonCharacterGirlfriend" width="70" height="70" padding="8" iconPosition="top">
+                            Girlfriend
+                        </button>
+                        <button id="buttonCharacterPlayer" width="70" height="70" padding="8" iconPosition="top">
+                            Boyfriend
+                        </button>
+                    </hbox>
                 </grid>
-                <hbox width="100%">
-                    <button id="buttonCharacterOpponent" width="70" height="70" padding="8" iconPosition="top">
-                        Daddy Dearest
-                    </button>
-                    <button id="buttonCharacterGirlfriend" width="70" height="70" padding="8" iconPosition="top">
-                        Girlfriend
-                    </button>
-                    <button id="buttonCharacterPlayer" width="70" height="70" padding="8" iconPosition="top">
-                        Boyfriend
-                    </button>
-                </hbox>
-            </vbox>
-        </frame>
-        <frame text="Difficulty: Normal" width="100%" height="170" id="frameDifficulty">
-            <grid columns="2">
-                <label text="Starting BPM" verticalAlign="center" />
-                <number-stepper id="inputBPM" pos="100" step="1" min="10" max="500" precision="1" horizontalAlign="right" tooltip="Adjust the BPM of the song, which helps align the grid and character animations to the music." />
-                <label text="Starting Time Signature" verticalAlign="center" />
-                <dropdown id="inputTimeSignature" value="4/4" horizontalAlign="right" tooltip="Adjust the time signature of the song, which helps align the grid.">
-                    <data>
-                        <item id="2/4" text="2/4" />
-                        <item id="3/4" text="3/4" />
-                        <item id="4/4" text="4/4" />
-                        <item id="5/4" text="5/4" />
-                        <item id="6/4" text="6/4" />
-                        <item id="3/8" text="3/8" />
-                        <item id="5/8" text="5/8" />
-                        <item id="7/8" text="7/8" />
-                        <item id="9/8" text="9/8" />
-                        <item id="15/16" text="15/16" />
-                    </data>
-                </dropdown>
-                <label id="labelScrollSpeed" text="Scroll Speed: 1.0x" />
-                <spacer />
-                <slider id="inputScrollSpeed" pos="1.0" step="0.1" precision="1" min="0.5" max="5.0" tooltip="Adjust the relative speed at which the notes move." />
-                <spacer />
-                <label id="labelDifficultyRating" text="Difficulty Rank" verticalAlign="center" />
-                <number-stepper id="inputDifficultyRating" pos="0" step="1" min="0" max="15" tooltip="Set the rating for this difficulty as shown in the Freeplay menu." />
-            </grid>
-        </frame>
-    </vbox>
+            </frame>
+            <frame text="Difficulty: Normal" width="100%" height="30%" id="frameDifficulty">
+                <grid columns="2">
+                    <label id="labelScrollSpeed" text="Scroll Speed: 1.0x" />
+                    <spacer />
+                    <slider id="inputScrollSpeed" pos="1.0" step="0.1" precision="1" min="0.5" max="5.0" tooltip="Adjust the relative speed at which the notes move." />
+                    <spacer />
+                    <label id="labelDifficultyRating" text="Difficulty Rank:" verticalAlign="center" />
+                    <number-stepper id="inputDifficultyRating" pos="0" step="1" min="0" max="15" tooltip="Set the rating for this difficulty as shown in the Freeplay menu." />
+                </grid>
+            </frame>
+        </vbox>
+        <vbox width="50%" height="100%">
+            <frame text="Timing Data" width="100%" id="frameTiming">
+                <grid columns="2">
+                    <label text="Starting BPM:" verticalAlign="center" />
+                    <number-stepper id="inputBPM" pos="100" step="0.1" min="10" max="500" precision="1" horizontalAlign="right" width="100" tooltip="Adjust the BPM of the song, which helps align the grid and character animations to the music." />
+                    <label text="Starting Time Signature" verticalAlign="center" />
+                    <spacer />
+                    <label text="Numerator:" verticalAlign="center" />
+                    <dropdown id="inputTSNum" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature numerator of the song, which helps align the grid.">
+                        <data>
+                            <item text="1" />
+                            <item text="2" />
+                            <item text="3" />
+                            <item text="4" />
+                            <item text="5" />
+                            <item text="6" />
+                            <item text="7" />
+                            <item text="8" />
+                            <item text="9" />
+                            <item text="10" />
+                            <item text="11" />
+                            <item text="12" />
+                            <item text="13" />
+                            <item text="14" />
+                            <item text="15" />
+                            <item text="16" />
+                        </data>
+                    </dropdown>
+                    <label text="Denominator:" verticalAlign="center" />
+                    <dropdown id="inputTSDen" value="4" horizontalAlign="right" width="50" tooltip="Adjust the time signature denominator of the song, which helps align the grid.">
+                        <data>
+                            <item text="2" />
+                            <item text="4" />
+                            <item text="8" />
+                            <item text="16" />
+                        </data>
+                    </dropdown>
+                </grid>
+            </frame>
+        </vbox>
+    </hbox>
 </collapsible-dialog>


### PR DESCRIPTION
<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
[Funkin/#4770](https://github.com/FunkinCrew/Funkin/pull/4770)

<!-- Briefly describe the issue(s) fixed. -->
## Description
Expands the selection of Time Signatures to two separate dropdowns and adds a dropdown for Time Changes.

Other changes:
- BPM stepper now allows for 3 decimals instead of just 1.
- The metadata window width is doubled in order to have enough space.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
![screenshot-2025-05-08-00-41-12](https://github.com/user-attachments/assets/b4ae7f34-d79c-4ab8-879b-2a86cd4ecaa2)
![screenshot-2025-05-08-00-41-23](https://github.com/user-attachments/assets/fbe98284-ae3b-4163-9c35-651d2de88ed4)
![screenshot-2025-05-08-00-41-28](https://github.com/user-attachments/assets/e957ab18-f816-48b3-a663-f0a2161272d2)

