### PR TITLE
[GITHUB] More PR size labels

### DIFF
--- a/.github/changed-lines-count-labeler.yml
+++ b/.github/changed-lines-count-labeler.yml
@@ -1,12 +1,22 @@
-# Add 'size: small' to any changes below 10 lines
+# Add 'size: tiny' to any changes of at most 4 lines
+'size: tiny':
+  max: 4
+
+# Add 'size: small' to any changes between 5 and 10 lines
 'size: small':
-  max: 9
+  min: 5
+  max: 10
 
-# Add 'size: medium' to any changes between 10 and 100 lines
+# Add 'size: medium' to any changes between 11 and 100 lines
 'size: medium':
-  min: 10
-  max: 99
+  min: 11
+  max: 100
 
-# Add 'size: large' to any changes of at least 100 lines
+# Add 'size: large' to any changes between 101 and 500 lines
 'size: large':
-  min: 100
+  min: 101
+  max: 500
+
+# Add 'size: huge' to any changes of more than 500 lines
+'size: huge':
+  min: 501


### PR DESCRIPTION
## Changes
Like https://github.com/FunkinCrew/Funkin/pull/5068, but for funkin.assets!
Adds `size: tiny` and `size: huge` to the PR size labeler workflow.