### PR TITLE
[BUGFIX + ENHANCEMENT] Use `SongNoteData` for `pico-speaker` and `otis-speaker` animations

### DIFF
--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -10,8 +10,7 @@ import funkin.graphics.shaders.AdjustColorShader;
 
 class OtisSpeakerCharacter extends AnimateAtlasCharacter
 {
-  var shootTimes:Array<Float> = [];
-  var shootDirs:Array<Int> = [];
+  var animNotes:Array<SongNoteData> = [];
 
   var pupilState:Int = 0;
 
@@ -140,7 +139,6 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
   function initTimemap():Void
   {
     trace('Initializing Otis timings...');
-    shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
     var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentVariation);
@@ -153,19 +151,14 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
     {
       trace('Initializing Otis (speaker); found `picospeaker` chart, continuing...');
     }
-    var animNotes:Array<SongNoteData> = animChart.notes;
+
+    animNotes = animChart.notes;
 
     // turns out sorting functions are completely useless in polymod right now and do nothing
     // i had to sort the whole pico chart by hand im gonna go insane
     animNotes.sort(function(a:SongNoteData, b:SongNoteData):Int {
       return FlxSort.byValues(FlxSort.ASCENDING, a.time, b.time);
     });
-
-    for (note in animNotes)
-    {
-      shootTimes.push(note.time);
-      shootDirs.push(note.data);
-    }
   }
 
   override function onUpdate(event:UpdateScriptEvent):Void
@@ -215,12 +208,10 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
     }
 
     // Each Pico animation is shifted from the array when it's time to play it.
-    while (shootTimes.length > 0 && shootTimes[0] <= Conductor.instance.songPosition)
+    while (animNotes.length > 0 && animNotes[0].time <= Conductor.instance.songPosition)
     {
-      var nextTime:Float = shootTimes.shift();
-      var nextDir:Int = shootDirs.shift();
-
-      playPicoAnimation(nextDir);
+      var data:SongNoteData = animNotes.shift();
+      playPicoAnimation(data.getDirection());
     }
   }
 

--- a/preload/scripts/characters/pico-speaker.hxc
+++ b/preload/scripts/characters/pico-speaker.hxc
@@ -11,8 +11,7 @@ import Lambda;
 
 class PicoSpeakerCharacter extends AnimateAtlasCharacter
 {
-  var shootTimes:Array<Float> = [];
-  var shootDirs:Array<Int> = [];
+  var animNotes:Array<SongNoteData> = [];
 
   function new()
   {
@@ -49,7 +48,6 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
   function initTimemap():Void
   {
     trace('Initializing Pico timings...');
-    shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
     var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker');
@@ -62,19 +60,13 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
     {
       trace('Initializing Pico (speaker); found `picospeaker` chart, continuing...');
     }
-    var animNotes:Array<SongNoteData> = animChart.notes;
+    animNotes = animChart.notes;
 
     // turns out sorting functions are completely useless in polymod right now and do nothing
     // i had to sort the whole pico chart by hand im gonna go insane
     animNotes.sort(function(a:SongNoteData, b:SongNoteData):Int {
       return FlxSort.byValues(FlxSort.ASCENDING, a.time, b.time);
     });
-
-    for (note in animNotes)
-    {
-      shootTimes.push(note.time);
-      shootDirs.push(note.data);
-    }
   }
 
   override function onUpdate(event:UpdateScriptEvent):Void
@@ -82,10 +74,10 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
     super.onUpdate(event);
 
     // Each Pico animation is shifted from the array when it's time to play it.
-    while (shootTimes.length > 0 && shootTimes[0] <= Conductor.instance.songPosition)
+    while (animNotes.length > 0 && animNotes[0].time <= Conductor.instance.songPosition)
     {
-      var nextTime:Float = shootTimes.shift();
-      var nextDir:Int = shootDirs.shift();
+      var data:SongNoteData = animNotes.shift();
+      var nextDir:Int = data.getDirection();
 
       if (nextDir == 3)
       {
@@ -95,6 +87,7 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
       {
         nextDir += FlxG.random.int(0, 1);
       }
+
       playPicoAnimation(nextDir);
     }
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes FunkinCrew/Funkin#5115

<!-- Briefly describe the issue(s) fixed. -->
## Description
Usually, `pico-speaker` and `otis-speaker` queue animations by having two seperate arrays for timing and direction. This PR changes this by directly using the `SongNoteData` class, which completely eliminates the need for two arrays.

This PR also fixes any inconsistencies caused by resetting the song.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
