### PR TITLE
[ENHANCEMENT] Shift Mommy Mearest's Pixel Icon to the left

### DIFF
--- a/preload/images/freeplay/icons/mommypixel.xml
+++ b/preload/images/freeplay/icons/mommypixel.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TextureAtlas imagePath="mommypixel.png" width="275" height="50">
-	<SubTexture name="idle0001" x="232" y="1" width="42" height="44" frameX="-11" frameY="-9" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="idle0001" x="232" y="1" width="42" height="44" frameX="4" frameY="-9" frameWidth="60" frameHeight="60"/>
 
-	<SubTexture name="confirm0001" x="94" y="1" width="43" height="45" frameX="-12" frameY="-8" frameWidth="60" frameHeight="60"/>
-	<SubTexture name="confirm0002" x="1" y="1" width="44" height="48" frameX="-8" frameY="-9" frameWidth="60" frameHeight="60"/>
-	<SubTexture name="confirm0003" x="186" y="1" width="43" height="44" frameX="-9" frameY="-13" frameWidth="60" frameHeight="60"/>
-	<SubTexture name="confirm0004" x="48" y="1" width="43" height="47" frameX="-9" frameY="-10" frameWidth="60" frameHeight="60"/>
-	<SubTexture name="confirm0005" x="140" y="1" width="43" height="45" frameX="-9" frameY="-12" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm0001" x="94" y="1" width="43" height="45" frameX="3" frameY="-8" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm0002" x="1" y="1" width="44" height="48" frameX="7" frameY="-9" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm0003" x="186" y="1" width="43" height="44" frameX="6" frameY="-13" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm0004" x="48" y="1" width="43" height="47" frameX="6" frameY="-10" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm0005" x="140" y="1" width="43" height="45" frameX="6" frameY="-12" frameWidth="60" frameHeight="60"/>
 
-	<SubTexture name="confirm-hold0001" x="140" y="1" width="43" height="45" frameX="-9" frameY="-12" frameWidth="60" frameHeight="60"/>
+	<SubTexture name="confirm-hold0001" x="140" y="1" width="43" height="45" frameX="6" frameY="-12" frameWidth="60" frameHeight="60"/>
 </TextureAtlas>


### PR DESCRIPTION
## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/4180

## Description
Shifts the pixel icon of Mommy Mearest by 15 pixels in the `.xml` file. Wish the same was done for the `parents-christmas` icon without there needing to be a hardcode for it but oh well.

## Screenshots/Videos

https://github.com/user-attachments/assets/d4a1e954-07e5-4710-b744-d4ba3feefc60

