### PR TITLE
[BUGFIX] Fix Nene (Pixel) using the wrong name

### DIFF
--- a/preload/data/characters/nene-pixel.json
+++ b/preload/data/characters/nene-pixel.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Nene",
+  "name": "Nene (Pixel)",
   "assetPath": "characters/nenePixel/nenePixel",
   "startingAnimation": "danceRight",
   "isPixel": true,


### PR DESCRIPTION
# P.R Summary:
This is the same issue as #158 where the name in the character JSON was incorrect.
_Nene -> Nene (Pixel)_
**This does not close any issues as far as I know.**

# Images:

## Before:
![image](https://github.com/user-attachments/assets/8dd8d6bb-4f08-4f48-b229-6ed354285e0c)

## After:
![image](https://github.com/user-attachments/assets/b4e83271-f311-4c71-b8a9-a7a43b497d52)

