### PR TITLE
[BUGFIX] Fix the Tankman variants using the same name

### DIFF
--- a/preload/data/characters/tankman-atlas.json
+++ b/preload/data/characters/tankman-atlas.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "name": "Tankman",
+  "name": "Tankman (Atlas)",
   "renderType": "animateatlas",
   "assetPath": "characters/tankman",
   "flipX": true,

--- a/preload/data/characters/tankman-bloody.json
+++ b/preload/data/characters/tankman-bloody.json
@@ -4,7 +4,7 @@
   "offsets": [0, -50],
   "danceEvery": 1,
   "scale": 1,
-  "name": "Tankman",
+  "name": "Tankman (Bloody)",
   "flipX": true,
   "cameraOffsets": [0, 0],
   "singTime": 8,


### PR DESCRIPTION
## Description
For some reason, the names of Tankman's atlas and bloody variants are once again not named properly.

## Before/After
![evidence1](https://github.com/user-attachments/assets/0aa5aa57-4072-41b9-b8d7-3c65acde8312)
![evidence2](https://github.com/user-attachments/assets/6a32939e-1eff-4238-8aa0-dea8e8dfe622)
![resolve1](https://github.com/user-attachments/assets/08fb5b8b-81e8-4f65-8a92-bcc6e6b899c8)
![resolve2](https://github.com/user-attachments/assets/dad37cc3-8a13-43a9-90fc-0f0a70800d95)
