### PR TITLE
[BUGFIX] Sync idle animation for 'spooky-dark' with regular idle

### DIFF
--- a/preload/data/characters/spooky-dark.json
+++ b/preload/data/characters/spooky-dark.json
@@ -13,14 +13,14 @@
     {
       "name": "danceLeft",
       "prefix": "Idle",
-      "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7],
+      "frameIndices": [1, 2, 3, 4, 5, 6, 7, 8],
       "frameRate": 24,
       "offsets": [0, 0]
     },
     {
       "name": "danceRight",
       "prefix": "Idle",
-      "frameIndices": [8, 9, 10, 11, 12, 13, 14, 15],
+      "frameIndices": [9, 10, 11, 12, 13, 14, 15, 16],
       "frameRate": 24,
       "offsets": [0, 0]
     },


### PR DESCRIPTION
This PR fixes the frame indice set for 'spooky-dark' being off by one frame, as #159 did only for the normal variant.
The issue only affects 'danceLeft' and 'danceRight' for this character.

Fixes https://github.com/FunkinCrew/Funkin/issues/5541
