### PR TITLE
[BUGFIX] Fix the `pico-blazin` death sprite being offset and causing lag

### DIFF
--- a/preload/scripts/characters/pico-blazin.hxc
+++ b/preload/scripts/characters/pico-blazin.hxc
@@ -6,6 +6,7 @@ import funkin.play.PauseSubState;
 import funkin.graphics.FunkinSprite;
 import funkin.play.character.AnimateAtlasCharacter;
 import funkin.play.GameOverSubState;
+import funkin.FunkinMemory;
 import StringTools;
 
 class PicoBlazinCharacter extends AnimateAtlasCharacter
@@ -28,6 +29,9 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
     GameOverSubState.blueBallSuffix = '-pico-gutpunch';
 
     PauseSubState.musicSuffix = '-pico';
+
+    // Precache the death anim.
+    FunkinMemory.cacheTexture(Paths.image('picoBlazinDeathConfirm', 'weekend1'));
   }
 
   var cantUppercut = false;
@@ -168,7 +172,7 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
 
   function doDeathConfirm():Void
   {
-    var picoDeathConfirm:FunkinSprite = FunkinSprite.createSparrow(this.x + 905, this.y + 1030, 'picoBlazinDeathConfirm');
+    var picoDeathConfirm:FunkinSprite = FunkinSprite.createSparrow(this.x + 1045, this.y + 1216, 'picoBlazinDeathConfirm');
     picoDeathConfirm.animation.addByPrefix('confirm', "Pico Gut Punch Death0", 24, false);
     picoDeathConfirm.animation.play('confirm');
     picoDeathConfirm.scale.set(1.75, 1.75);


### PR DESCRIPTION
## Associated Funkin PR
N/A

## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5644

## Description
Through the power of patience the x and y position for the `picoDeathConfirm` have been shifted. Also adds caching to `FunkinMemory` for the death sprite because Jackxson asked me to.

## Screenshots/Videos

https://github.com/user-attachments/assets/bff74ea3-5354-4ac8-82bb-e680c0793ccf
