### PR TITLE
Add charter field to New Chart Dialog

### DIFF
--- a/preload/data/ui/chart-editor/dialogs/song-metadata.xml
+++ b/preload/data/ui/chart-editor/dialogs/song-metadata.xml
@@ -8,6 +8,8 @@
 				<textfield id="inputSongName" value="Bopeebo" />
 				<label text="Song Artist:" verticalAlign="center" horizontalAlign="right" />
 				<textfield id="inputSongArtist" value="Kawai Sprite" />
+				<label text="Charter:" verticalAlign="center" horizontalAlign="right" />
+				<textfield id="inputSongCharter" value="ninjamuffin99 + MtH" />
 				<label text="Stage:" verticalAlign="center" horizontalAlign="right" />
 				<dropdown id="inputStage" value="Main Stage" dropdownSize="10" dropdownWidth="300" searchable="true" width="100%" horizontalAlign="right">
 					<data>


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/5657
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description
Adds a charter field to the song metadata dialog that shows up when you're creating a new chart.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="328" height="397" alt="image" src="https://github.com/user-attachments/assets/b31fee2d-f5aa-4a04-ae5f-63fd447b6b35" />