### PR TITLE
[BUGFIX] Fix Week 3 train never appearing again after beating a Week 3 song

### DIFF
--- a/preload/scripts/stages/phillyTrain.hxc
+++ b/preload/scripts/stages/phillyTrain.hxc
@@ -25,6 +25,7 @@ class PhillyTrainStage extends Stage
   function buildStage()
   {
     super.buildStage();
+    trainEnabled = true;
 
     // NOTE: You pass the constructor variables directly, not as an array.
     lightShader = ScriptedFlxRuntimeShader.init('BuildingEffectShader', 1.0);

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -52,6 +52,7 @@ class PhillyTrainErectStage extends Stage
   {
     super.onCreate(event);
 
+    trainEnabled = true;
     hasPlayedInGameCutscene = false;
     cutsceneSkipped = false;
     canSkipCutscene = false;


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes the bug caused by @sector-a's PR that causes the train to never appear after beating any week 3 song once. Makes sure to re-enable the train whenever the stage builds.