### PR TITLE
[BUGFIX] Fix Lightning Rarely Appearing in South and Monster in Story Mode

### DIFF
--- a/preload/scripts/stages/spookyMansion.hxc
+++ b/preload/scripts/stages/spookyMansion.hxc
@@ -65,13 +65,6 @@ class SpookyMansionStage extends Stage
   {
     super.onBeatHit(event);
 
-    // Reset lightning variables at the start of every song
-    if (event.beat == 0)
-    {
-      lightningStrikeBeat = 0;
-      lightningStrikeOffset = 8;
-    }
-
     // Play lightning on sync at the start of this specific song.
     // TODO: Rework this after chart format redesign.
     if (PlayState.instance.currentSong != null)
@@ -118,5 +111,16 @@ class SpookyMansionStage extends Stage
     // Properly reset lightning when restarting the song.
     lightningStrikeBeat = 0;
     lightningStrikeOffset = 8;
+  }
+  
+  function onCountdownStart(event:CountdownScriptEvent):Void
+  {
+    super.onCountdownStart(event);
+    // Reset lightning variables at the start of every song
+    if (event.beat == 0)
+    {
+      lightningStrikeBeat = 0;
+      lightningStrikeOffset = 8;
+    }
   }
 }

--- a/preload/scripts/stages/spookyMansion.hxc
+++ b/preload/scripts/stages/spookyMansion.hxc
@@ -65,6 +65,13 @@ class SpookyMansionStage extends Stage
   {
     super.onBeatHit(event);
 
+    // Reset lightning variables at the start of every song
+    if (event.beat == 0)
+    {
+      lightningStrikeBeat = 0;
+      lightningStrikeOffset = 8;
+    }
+
     // Play lightning on sync at the start of this specific song.
     // TODO: Rework this after chart format redesign.
     if (PlayState.instance.currentSong != null)


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Lightning variables weren't properly reset at the start of every song in story mode, causing the first lightning strike to be delayed quite far into the level. This is most noticeable on Monster because the first lightning strike only plays near the end of the song, making it seem like lightning isn't happening at all. The lightning starts playing at normal intervals again after the first lightning strike, so I just had to add this check to make sure the first lightning strike played near the beginning of the song.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/ae539a64-655d-4101-8a1a-417918e9e592

