### PR TITLE
[BUGFIX] Fix a script error when re-entering phillyTrainErect

### DIFF
--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -593,7 +593,11 @@ class PhillyTrainErectStage extends Stage
   function kill()
   {
     super.kill();
-    if (cutsceneTimerManager != null) cutsceneTimerManager.destroy();
+    if (cutsceneTimerManager != null)
+    {
+        cutsceneTimerManager.destroy();
+        cutsceneTimerManager = null;
+    }
     lightShader = null;
   }
 }


### PR DESCRIPTION
## Associated Funkin PR
N/A

## Linked Issues
N/A

## Description
When entering a week 3 pico mix song, the `cutsceneTimerManager` is created. However, it is never properly set to `null` after exiting, leading to a script error if entering a week 3 erect song, since they don't have cutscenes.

## Screenshots/Videos
im kinda lazy actually
