### PR TITLE
[ENHANCEMENT] Manually Offset Splashes

### DIFF
--- a/preload/data/notestyles/funkin.json
+++ b/preload/data/notestyles/funkin.json
@@ -45,6 +45,7 @@
     "noteSplash": {
       "assetPath": "shared:noteSplashes",
       "alpha": 0.8,
+      "offsets": [25, -5],
       "data": {
         "enabled": true,
         "leftSplashes": [


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
[#FunkinCrew/Funkin3105](https://github.com/FunkinCrew/Funkin/issues/3105)
[#FunkinCrew/Funkin3427](https://github.com/FunkinCrew/Funkin/issues/3427)

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR centers the note splashes, as they were a little bit off centered. I will make tiny adjustments to this if needed. People can give feedback for this PR.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1280" height="720" alt="screenshot-2025-08-19-15-49-14" src="https://github.com/user-attachments/assets/ee106649-63e4-471a-a180-73a6c1ce70ab" />
<img width="1280" height="720" alt="screenshot-2025-08-19-15-49-00" src="https://github.com/user-attachments/assets/d1ade60e-596c-4edf-9464-67c67bd70891" />
<img width="205" height="262" alt="Screenshot 2025-08-19 154744" src="https://github.com/user-attachments/assets/2b995ae3-3e93-4a81-a6a5-309074ed1bff" />
<img width="189" height="255" alt="Screenshot 2025-08-19 154840" src="https://github.com/user-attachments/assets/65f92d35-1b29-40fe-8b0d-a9510c0e03ad" />

