### PR TITLE
Improved offsets for BF and GF animations

### DIFF
--- a/preload/data/characters/bf-car.json
+++ b/preload/data/characters/bf-car.json
@@ -96,6 +96,14 @@
       "offsets": [18, 18]
     },
     {
+      "name": "hit-hold",
+      "prefix": "BF hit",
+      "assetPath": "characters/BOYFRIEND",
+      "frameIndices": [10, 11],
+      "looped": true,
+      "offsets": [18, 18]
+    },
+    {
       "name": "dodge",
       "prefix": "boyfriend dodge",
       "assetPath": "characters/BOYFRIEND",

--- a/preload/data/characters/bf-car.json
+++ b/preload/data/characters/bf-car.json
@@ -12,94 +12,94 @@
     {
       "name": "idle",
       "prefix": "BF idle dance",
-      "offsets": [-5, 0]
+      "offsets": [0, 0]
     },
     {
       "name": "idle-hold",
       "prefix": "BF idle dance",
       "frameIndices": [10, 11, 12, 13],
       "looped": true,
-      "offsets": [-5, 0]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "BF NOTE LEFT0",
-      "offsets": [12, -6]
+      "offsets": [14, -6]
     },
     {
       "name": "singLEFT-hold",
       "prefix": "BF NOTE LEFT0",
       "frameIndices": [10, 11, 12, 13],
       "looped": true,
-      "offsets": [12, -6]
+      "offsets": [14, -6]
     },
     {
       "name": "singDOWN",
       "prefix": "BF NOTE DOWN0",
-      "offsets": [-10, -50]
+      "offsets": [-23, -51]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "BF NOTE DOWN0",
       "frameIndices": [10, 11, 12, 13],
       "looped": true,
-      "offsets": [-10, -50]
+      "offsets": [-23, -51]
     },
     {
       "name": "singUP",
       "prefix": "BF NOTE UP0",
-      "offsets": [-29, 27]
+      "offsets": [-43, 34]
     },
     {
       "name": "singUP-hold",
       "prefix": "BF NOTE UP0",
       "frameIndices": [10, 11, 12, 13],
       "looped": true,
-      "offsets": [-29, 27]
+      "offsets": [-43, 34]
     },
     {
       "name": "singRIGHT",
       "prefix": "BF NOTE RIGHT0",
-      "offsets": [-38, -7]
+      "offsets": [-47, -5]
     },
     {
       "name": "singRIGHT-hold",
       "prefix": "BF NOTE RIGHT0",
       "frameIndices": [10, 11, 12, 13],
       "looped": true,
-      "offsets": [-38, -7]
+      "offsets": [-47, -5]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 24]
+      "offsets": [14, 20]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "BF NOTE DOWN MISS",
-      "offsets": [-11, -19]
+      "offsets": [-23, -21]
     },
     {
       "name": "singUPmiss",
       "prefix": "BF NOTE UP MISS",
-      "offsets": [-29, 27]
+      "offsets": [-39, 34]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "BF NOTE RIGHT MISS",
-      "offsets": [-30, 21]
+      "offsets": [-41, 23]
     },
     {
-      "name": "firstDeath",
-      "prefix": "BF dies",
+      "name": "hit",
+      "prefix": "BF hit",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 11]
+      "offsets": [18, 18]
     },
     {
       "name": "dodge",
       "prefix": "boyfriend dodge",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [2, -8]
     },
     {
       "name": "dodge-hold",
@@ -107,26 +107,26 @@
       "frameIndices": [10, 11, 12],
       "looped": true,
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [2, -8]
     },
     {
-      "name": "hit",
-      "prefix": "BF hit",
+      "name": "firstDeath",
+      "prefix": "BF dies",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [28, 5]
     },
     {
       "name": "deathLoop",
       "prefix": "BF Dead Loop",
       "assetPath": "characters/BOYFRIEND",
       "looped": true,
-      "offsets": [-37, 5]
+      "offsets": [28, -1]
     },
     {
       "name": "deathConfirm",
       "prefix": "BF Dead confirm",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 69]
+      "offsets": [28, 63]
     }
   ]
 }

--- a/preload/data/characters/bf-christmas.json
+++ b/preload/data/characters/bf-christmas.json
@@ -10,14 +10,9 @@
   "singTime": 8.0,
   "animations": [
     {
-      "name": "hey",
-      "prefix": "BF HEY!!",
-      "offsets": [-2, 5]
-    },
-    {
       "name": "idle",
       "prefix": "BF idle dance",
-      "offsets": [-5, 0]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
@@ -27,68 +22,73 @@
     {
       "name": "singDOWN",
       "prefix": "BF NOTE DOWN0",
-      "offsets": [-10, -50]
+      "offsets": [-22, -47]
     },
     {
       "name": "singUP",
       "prefix": "BF NOTE UP0",
-      "offsets": [-29, 27]
+      "offsets": [-39, 31]
     },
     {
       "name": "singRIGHT",
       "prefix": "BF NOTE RIGHT0",
-      "offsets": [-38, -7]
+      "offsets": [-53, -5]
+    },
+    {
+      "name": "singLEFTmiss",
+      "prefix": "BF NOTE LEFT MISS",
+      "offsets": [12, 20]
+    },
+    {
+      "name": "singDOWNmiss",
+      "prefix": "BF NOTE DOWN MISS",
+      "offsets": [-22, -17]
+    },
+    {
+      "name": "singUPmiss",
+      "prefix": "BF NOTE UP MISS",
+      "offsets": [-33, 31]
+    },
+    {
+      "name": "singRIGHTmiss",
+      "prefix": "BF NOTE RIGHT MISS",
+      "offsets": [-42, 23]
     },
     {
       "name": "singDOWN-censor",
       "assetPath": "characters/bfChristmas_Censored",
       "prefix": "bf swear down",
-      "offsets": [-10, -50]
+      "offsets": [-22, -47]
     },
     {
       "name": "singRIGHT-censor",
       "assetPath": "characters/bfChristmas_Censored",
       "prefix": "bf swear right",
-      "offsets": [-38, -7]
+      "offsets": [-53, -5]
     },
     {
-      "name": "singLEFTmiss",
-      "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 24]
-    },
-    {
-      "name": "singDOWNmiss",
-      "prefix": "BF NOTE DOWN MISS",
-      "offsets": [-11, -19]
-    },
-    {
-      "name": "singUPmiss",
-      "prefix": "BF NOTE UP MISS",
-      "offsets": [-29, 27]
-    },
-    {
-      "name": "singRIGHTmiss",
-      "prefix": "BF NOTE RIGHT MISS",
-      "offsets": [-30, 21]
+      "name": "hey",
+      "prefix": "BF HEY!!",
+      "offsets": [1, 6]
     },
     {
       "name": "firstDeath",
       "prefix": "BF dies",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 11]
+      "offsets": [24, 3]
     },
     {
       "name": "deathLoop",
       "prefix": "BF Dead Loop",
       "assetPath": "characters/BOYFRIEND",
       "looped": true,
-      "offsets": [-37, 5]
+      "offsets": [24, -3]
     },
     {
       "name": "deathConfirm",
       "prefix": "BF Dead confirm",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 69]
+      "offsets": [24, 61]
     }
   ]
 }

--- a/preload/data/characters/bf-christmas.json
+++ b/preload/data/characters/bf-christmas.json
@@ -17,7 +17,7 @@
     {
       "name": "singLEFT",
       "prefix": "BF NOTE LEFT0",
-      "offsets": [12, -6]
+      "offsets": [13, -6]
     },
     {
       "name": "singDOWN",
@@ -37,7 +37,7 @@
     {
       "name": "singLEFTmiss",
       "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 20]
+      "offsets": [13, 20]
     },
     {
       "name": "singDOWNmiss",

--- a/preload/data/characters/bf-dark.json
+++ b/preload/data/characters/bf-dark.json
@@ -13,82 +13,82 @@
     {
       "name": "idle",
       "prefix": "BF idle dance",
-      "offsets": [-5, 0]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "BF NOTE LEFT0",
-      "offsets": [12, -6]
+      "offsets": [14, -6]
     },
     {
       "name": "singDOWN",
       "prefix": "BF NOTE DOWN0",
-      "offsets": [-10, -50]
+      "offsets": [-23, -51]
     },
     {
       "name": "singUP",
       "prefix": "BF NOTE UP0",
-      "offsets": [-29, 27]
+      "offsets": [-43, 34]
     },
     {
       "name": "singRIGHT",
       "prefix": "BF NOTE RIGHT0",
-      "offsets": [-38, -7]
+      "offsets": [-47, -5]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 24]
+      "offsets": [14, 20]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "BF NOTE DOWN MISS",
-      "offsets": [-11, -19]
+      "offsets": [-23, -21]
     },
     {
       "name": "singUPmiss",
       "prefix": "BF NOTE UP MISS",
-      "offsets": [-29, 27]
+      "offsets": [-39, 34]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "BF NOTE RIGHT MISS",
-      "offsets": [-30, 21]
+      "offsets": [-41, 23]
     },
     {
       "name": "hey",
       "prefix": "BF HEY!!",
-      "offsets": [7, 4]
+      "offsets": [1, 6]
     },
     {
       "name": "scared",
       "prefix": "BF idle shaking",
-      "offsets": [-4, 0]
+      "offsets": [-1, 1]
     },
     {
       "name": "firstDeath",
       "prefix": "BF dies",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 11]
+      "offsets": [28, 5]
     },
     {
       "name": "fakeoutDeath",
       "prefix": "BF dies",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 11]
+      "offsets": [28, 5]
     },
     {
       "name": "deathLoop",
       "prefix": "BF Dead Loop",
       "looped": true,
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 5]
+      "offsets": [28, -1]
     },
     {
       "name": "deathConfirm",
       "prefix": "BF Dead confirm",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [-37, 69]
+      "offsets": [28, 63]
     }
   ]
 }

--- a/preload/data/characters/bf-holding-gf.json
+++ b/preload/data/characters/bf-holding-gf.json
@@ -9,31 +9,6 @@
   },
   "animations": [
     {
-      "name": "singUP",
-      "prefix": "BF Dead with GF Loop",
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "firstDeath",
-      "prefix": "BF Dies with GF",
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [37, 14]
-    },
-    {
-      "name": "deathConfirm",
-      "prefix": "RETRY confirm holding gf",
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [37, 28]
-    },
-    {
-      "name": "deathLoop",
-      "prefix": "BF Dead with GF Loop",
-      "looped": true,
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [37, -3]
-    },
-    {
       "name": "idle",
       "prefix": "BF idle dance w gf0",
       "offsets": [0, 0]
@@ -41,47 +16,66 @@
     {
       "name": "singLEFT",
       "prefix": "BF NOTE LEFT0",
-      "offsets": [12, 7]
+      "offsets": [12, 3]
     },
     {
       "name": "singDOWN",
       "prefix": "BF NOTE DOWN0",
-      "offsets": [-10, -10]
+      "offsets": [-23, -13]
     },
     {
       "name": "singUP",
       "prefix": "BF NOTE UP0",
-      "offsets": [-29, 10]
+      "offsets": [-37, 14]
     },
     {
       "name": "singRIGHT",
       "prefix": "BF NOTE RIGHT0",
-      "offsets": [-41, 23]
+      "offsets": [-49, 21]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 7]
+      "offsets": [12, 4]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "BF NOTE DOWN MISS",
-      "offsets": [-10, -10]
+      "offsets": [-23, -11]
     },
     {
       "name": "singUPmiss",
       "prefix": "BF NOTE UP MISS",
-      "offsets": [-29, 10]
+      "offsets": [-33, 14]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "BF NOTE RIGHT MISS",
-      "offsets": [-41, 23]
+      "offsets": [-43, 37]
     },
     {
       "name": "bfCatch",
       "prefix": "BF catches GF",
-      "offsets": [0, 0]
+      "offsets": [4, 90]
+    },
+    {
+      "name": "firstDeath",
+      "prefix": "BF Dies with GF",
+      "assetPath": "characters/bfHoldingGF-DEAD",
+      "offsets": [27, 28]
+    },
+    {
+      "name": "deathLoop",
+      "prefix": "BF Dead with GF Loop",
+      "looped": true,
+      "assetPath": "characters/bfHoldingGF-DEAD",
+      "offsets": [27, 11]
+    },
+    {
+      "name": "deathConfirm",
+      "prefix": "RETRY confirm holding gf",
+      "assetPath": "characters/bfHoldingGF-DEAD",
+      "offsets": [27, 42]
     }
   ]
 }

--- a/preload/data/characters/bf-pixel.json
+++ b/preload/data/characters/bf-pixel.json
@@ -21,19 +21,9 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singUP",
-      "prefix": "BF UP NOTE instance 10",
-      "offsets": [0, 0]
-    },
-    {
       "name": "singLEFT",
       "prefix": "BF LEFT NOTE instance 10",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singRIGHT",
-      "prefix": "BF RIGHT NOTE instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singDOWN",
@@ -41,19 +31,19 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singUPmiss",
-      "prefix": "BF UP MISS instance 10",
+      "name": "singUP",
+      "prefix": "BF UP NOTE instance 10",
+      "offsets": [-1, 0]
+    },
+    {
+      "name": "singRIGHT",
+      "prefix": "BF RIGHT NOTE instance 10",
       "offsets": [0, 0]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF LEFT MISS instance 10",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singRIGHTmiss",
-      "prefix": "BF RIGHT MISS instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singDOWNmiss",
@@ -61,23 +51,33 @@
       "offsets": [0, 0]
     },
     {
+      "name": "singUPmiss",
+      "prefix": "BF UP MISS instance 10",
+      "offsets": [-1, 0]
+    },
+    {
+      "name": "singRIGHTmiss",
+      "prefix": "BF RIGHT MISS instance 10",
+      "offsets": [0, 0]
+    },
+    {
       "name": "firstDeath",
       "prefix": "BF Dies pixel",
       "assetPath": "characters/bfPixelsDEAD",
-      "offsets": [8.33, 0]
+      "offsets": [8, -1]
     },
     {
       "name": "deathLoop",
       "prefix": "Retry Loop",
       "assetPath": "characters/bfPixelsDEAD",
       "looped": true,
-      "offsets": [3.33, -2.08]
+      "offsets": [3, -3]
     },
     {
       "name": "deathConfirm",
       "prefix": "RETRY CONFIRM",
       "assetPath": "characters/bfPixelsDEAD",
-      "offsets": [3.33, -2.08]
+      "offsets": [3, -3]
     }
   ]
 }

--- a/preload/data/characters/bf.json
+++ b/preload/data/characters/bf.json
@@ -9,87 +9,69 @@
     {
       "name": "idle",
       "prefix": "BF idle dance",
-      "offsets": [-5, 0]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "BF NOTE LEFT0",
-      "offsets": [12, -6]
+      "offsets": [14, -6]
     },
     {
       "name": "singDOWN",
       "prefix": "BF NOTE DOWN0",
-      "offsets": [-10, -50]
+      "offsets": [-23, -51]
     },
     {
       "name": "singUP",
       "prefix": "BF NOTE UP0",
-      "offsets": [-29, 27]
+      "offsets": [-43, 34]
     },
     {
       "name": "singRIGHT",
       "prefix": "BF NOTE RIGHT0",
-      "offsets": [-38, -7]
+      "offsets": [-47, -5]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF NOTE LEFT MISS",
-      "offsets": [12, 24]
+      "offsets": [14, 20]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "BF NOTE DOWN MISS",
-      "offsets": [-11, -19]
+      "offsets": [-23, -21]
     },
     {
       "name": "singUPmiss",
       "prefix": "BF NOTE UP MISS",
-      "offsets": [-29, 27]
+      "offsets": [-39, 34]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "BF NOTE RIGHT MISS",
-      "offsets": [-30, 21]
-    },
-    {
-      "name": "preAttack",
-      "prefix": "bf pre attack",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "attack",
-      "prefix": "boyfriend attack",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "dodge",
-      "prefix": "boyfriend dodge",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "dodge-hold",
-      "prefix": "boyfriend dodge",
-      "frameIndices": [10, 11, 12],
-      "looped": true,
-      "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [-41, 23]
     },
     {
       "name": "hey",
       "prefix": "BF HEY!!",
-      "offsets": [7, 4]
+      "offsets": [1, 6]
     },
     {
       "name": "cheer",
       "prefix": "Cheer",
       "assetPath": "characters/BFCheer",
-      "offsets": [0, 0]
+      "offsets": [-28, 20]
+    },
+    {
+      "name": "scared",
+      "prefix": "BF idle shaking",
+      "offsets": [-1, 1]
     },
     {
       "name": "hit",
       "prefix": "BF hit",
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [18, 18]
     },
     {
       "name": "hit-hold",
@@ -97,33 +79,56 @@
       "frameIndices": [10, 11],
       "looped": true,
       "assetPath": "characters/BOYFRIEND",
-      "offsets": [0, 0]
+      "offsets": [18, 18]
+    },
+    {
+      "name": "dodge",
+      "prefix": "boyfriend dodge",
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [2, -8]
+    },
+    {
+      "name": "dodge-hold",
+      "prefix": "boyfriend dodge",
+      "frameIndices": [10, 11, 12],
+      "looped": true,
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [2, -8]
+    },
+    {
+      "name": "preAttack",
+      "prefix": "bf pre attack",
+      "offsets": [-39, -38]
+    },
+    {
+      "name": "attack",
+      "prefix": "boyfriend attack",
+      "offsets": [301, 272]
     },
     {
       "name": "firstDeath",
       "prefix": "BF dies",
-      "offsets": [-37, 11]
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [28, 5]
     },
     {
       "name": "fakeoutDeath",
       "prefix": "BF dies",
-      "offsets": [-37, 11]
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [28, 5]
     },
     {
       "name": "deathLoop",
       "prefix": "BF Dead Loop",
       "looped": true,
-      "offsets": [-37, 5]
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [28, -1]
     },
     {
       "name": "deathConfirm",
       "prefix": "BF Dead confirm",
-      "offsets": [-37, 69]
-    },
-    {
-      "name": "scared",
-      "prefix": "BF idle shaking",
-      "offsets": [-4, 0]
+      "assetPath": "characters/BOYFRIEND",
+      "offsets": [28, 63]
     }
   ]
 }

--- a/preload/data/characters/gf-car.json
+++ b/preload/data/characters/gf-car.json
@@ -14,9 +14,7 @@
     {
       "name": "danceRight",
       "prefix": "GF Dancing Beat Hair blowing CAR",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "offsets": [0, 0]
     },
     {
@@ -30,7 +28,7 @@
       "name": "duck",
       "prefix": "GF Duck",
       "frameIndices": [0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3],
-      "offsets": [0, -100]
+      "offsets": [5, -86]
     }
   ]
 }

--- a/preload/data/characters/gf-christmas.json
+++ b/preload/data/characters/gf-christmas.json
@@ -8,37 +8,35 @@
       "name": "danceLeft",
       "prefix": "GF Dancing Beat",
       "frameIndices": [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [0, -9]
+      "offsets": [0, 0]
     },
     {
       "name": "danceRight",
       "prefix": "GF Dancing Beat",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, -9]
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      "offsets": [0, 0]
+    },
+    {
+      "name": "cheer",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
+    },
+    {
+      "name": "combo50",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
     },
     {
       "name": "sad",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
-    },
-    {
-      "name": "cheer",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "combo50",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
+      "offsets": [0, -12]
     },
     {
       "name": "drop70",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [0, -12]
     }
   ]
 }

--- a/preload/data/characters/gf-dark.json
+++ b/preload/data/characters/gf-dark.json
@@ -14,42 +14,40 @@
       "name": "danceLeft",
       "prefix": "GF Dancing Beat",
       "frameIndices": [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [0, -9]
+      "offsets": [0, 0]
     },
     {
       "name": "danceRight",
       "prefix": "GF Dancing Beat",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, -9]
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      "offsets": [0, 0]
+    },
+    {
+      "name": "cheer",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
+    },
+    {
+      "name": "combo50",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
     },
     {
       "name": "sad",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
-    },
-    {
-      "name": "cheer",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "combo50",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
+      "offsets": [-2, -12]
     },
     {
       "name": "drop70",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [-2, -12]
     },
     {
       "name": "scared",
       "prefix": "GF FEAR",
-      "offsets": [-2, -17]
+      "offsets": [-2, -8]
     }
   ]
 }

--- a/preload/data/characters/gf-pixel.json
+++ b/preload/data/characters/gf-pixel.json
@@ -15,15 +15,7 @@
     {
       "name": "danceRight",
       "prefix": "GF IDLE",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singUP",
-      "prefix": "GF IDLE",
-      "frameIndices": [2],
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "offsets": [0, 0]
     }
   ]

--- a/preload/data/characters/gf-tankmen.json
+++ b/preload/data/characters/gf-tankmen.json
@@ -8,27 +8,25 @@
       "name": "danceLeft",
       "prefix": "GF Dancing at Gunpoint",
       "frameIndices": [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [0, -9]
+      "offsets": [0, 0]
     },
     {
       "name": "danceRight",
       "prefix": "GF Dancing at Gunpoint",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, -9]
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      "offsets": [0, 0]
     },
     {
       "name": "sad",
       "prefix": "GF Crying at Gunpoint",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [0, -18]
     },
     {
       "name": "drop70",
       "prefix": "GF Crying at Gunpoint",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [0, -18]
     }
   ]
 }

--- a/preload/data/characters/gf.json
+++ b/preload/data/characters/gf.json
@@ -9,74 +9,72 @@
       "name": "danceLeft",
       "prefix": "GF Dancing Beat",
       "frameIndices": [30, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [0, -9]
+      "offsets": [0, 0]
     },
     {
       "name": "danceRight",
       "prefix": "GF Dancing Beat",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, -9]
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      "offsets": [0, 0]
+    },
+    {
+      "name": "singLEFT",
+      "prefix": "GF left note",
+      "offsets": [0, -10]
+    },
+    {
+      "name": "singDOWN",
+      "prefix": "GF Down Note",
+      "offsets": [1, -11]
+    },
+    {
+      "name": "singUP",
+      "prefix": "GF Up Note",
+      "offsets": [0, 13]
+    },
+    {
+      "name": "singRIGHT",
+      "prefix": "GF Right Note",
+      "offsets": [0, -11]
+    },
+    {
+      "name": "cheer",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
+    },
+    {
+      "name": "combo50",
+      "prefix": "GF Cheer",
+      "offsets": [0, 9]
     },
     {
       "name": "sad",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
-    },
-    {
-      "name": "singLEFT",
-      "prefix": "GF left note",
-      "offsets": [0, -19]
-    },
-    {
-      "name": "singDOWN",
-      "prefix": "GF Down Note",
-      "offsets": [0, -20]
-    },
-    {
-      "name": "singUP",
-      "prefix": "GF Up Note",
-      "offsets": [0, 4]
-    },
-    {
-      "name": "singRIGHT",
-      "prefix": "GF Right Note",
-      "offsets": [0, -20]
-    },
-    {
-      "name": "cheer",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "combo50",
-      "prefix": "GF Cheer",
-      "offsets": [0, 0]
+      "offsets": [-2, -12]
     },
     {
       "name": "drop70",
       "prefix": "gf sad",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      "offsets": [2, -21]
+      "offsets": [-2, -12]
+    },
+    {
+      "name": "scared",
+      "prefix": "GF FEAR",
+      "offsets": [-2, -8]
     },
     {
       "name": "hairBlow",
       "prefix": "GF Dancing Beat Hair blowing",
       "frameIndices": [0, 1, 2, 3],
-      "offsets": [45, -8]
+      "offsets": [45, 1]
     },
     {
       "name": "hairFall",
       "prefix": "GF Dancing Beat Hair Landing",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
-      "offsets": [0, -9]
-    },
-    {
-      "name": "scared",
-      "prefix": "GF FEAR",
-      "offsets": [-2, -17]
+      "offsets": [0, 0]
     }
   ]
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Divided into parts of #79
One issue that I mentioned in FunkinCrew/Funkin/issues/3105

<!-- Briefly describe the issue(s) fixed. -->
## Description
1. Changed the order of some animations in the `.json` files to make it a little more intuitive. It follows this order:
   - Idle/dance
   - Sing
   - Sing miss
   - Sing-alts (alt, censor, etc.)
   - Hey, cheer
   - Other animations during songs
   - Death animations
   - Cutscene animations

3. Added `"hit-hold"` to `bf-car.json`
4.  Added `"hey"` to `bf-christmas.json`
5. Removed `"singUP"` from `gf-pixel.json`, an unused animation that was probably added by mistake
6. Removed a possibly unintentional `"singUP"` animation that had `"prefix": "BF Dies with GF"` in `bf-holding-gf.json`

If you notice any errors or changes you don't like, let me know so I can change them.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
