### PR TITLE
Improved offsets for the Pico's gang

### DIFF
--- a/preload/data/characters/darnell.json
+++ b/preload/data/characters/darnell.json
@@ -13,51 +13,51 @@
     {
       "name": "singLEFT",
       "prefix": "Pose Left0",
-      "offsets": [1, 0]
+      "offsets": [0, 1]
     },
     {
       "name": "singLEFT-hold",
       "prefix": "Left Flame Loop0",
       "looped": true,
-      "offsets": [1, 0]
+      "offsets": [0, 1]
     },
     {
       "name": "singDOWN",
       "prefix": "Pose Down0",
-      "offsets": [0, -3]
+      "offsets": [14, -15]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "Down Flame Loop0",
       "looped": true,
-      "offsets": [0, -3]
+      "offsets": [14, -15]
     },
     {
       "name": "singUP",
       "prefix": "Pose Up0",
-      "offsets": [8, 5]
+      "offsets": [16, 3]
     },
     {
       "name": "singUP-hold",
       "prefix": "Up Flame Loop0",
       "looped": true,
-      "offsets": [8, 5]
+      "offsets": [16, 3]
     },
     {
       "name": "singRIGHT",
       "prefix": "Pose Right0",
-      "offsets": [4, 3]
+      "offsets": [1, 3]
     },
     {
       "name": "singRIGHT-hold",
       "prefix": "Right Flame Loop0",
       "looped": true,
-      "offsets": [4, 3]
+      "offsets": [1, 3]
     },
     {
       "name": "laugh",
       "prefix": "Laugh0",
-      "offsets": [0, 0]
+      "offsets": [2, 1]
     },
     {
       "name": "laughCutscene",
@@ -66,27 +66,27 @@
         1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6,
         1, 2, 3, 4, 5, 6
       ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "lightCan",
-      "prefix": "Light Can0",
-      "offsets": [8, 1]
-    },
-    {
-      "name": "kickCan",
-      "prefix": "Kick Up0",
-      "offsets": [15, 9]
-    },
-    {
-      "name": "kneeCan",
-      "prefix": "Knee Forward0",
-      "offsets": [7, -1]
+      "offsets": [2, 1]
     },
     {
       "name": "pissed",
       "prefix": "Gets Pissed0",
       "offsets": [0, 0]
+    },
+    {
+      "name": "lightCan",
+      "prefix": "Light Can0",
+      "offsets": [21, 22]
+    },
+    {
+      "name": "kickCan",
+      "prefix": "Kick Up0",
+      "offsets": [5, 18]
+    },
+    {
+      "name": "kneeCan",
+      "prefix": "Knee Forward0",
+      "offsets": [31, 12]
     }
   ]
 }

--- a/preload/data/characters/nene-christmas.json
+++ b/preload/data/characters/nene-christmas.json
@@ -14,48 +14,40 @@
     {
       "name": "danceRight",
       "prefix": "Nene Abot Idle xmas0",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "offsets": [0, 0]
     },
     {
       "name": "combo50",
       "prefix": "combo celebration 1 nene xmas0",
-      "offsets": [-120, 50]
-    },
-    {
-      "name": "drop70",
-      "prefix": "laughing nene xmas0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
-        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
-      ],
-      "offsets": [0, 0]
+      "offsets": [-125, 52]
     },
     {
       "name": "combo200",
       "prefix": "fawn nene xmas0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-        6, 6, 6, 6, 6, 6
-      ],
-      "offsets": [-50, -25]
+      "frameIndices": [0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6],
+      "offsets": [-43, -14]
+    },
+    {
+      "name": "drop70",
+      "prefix": "laughing nene xmas0",
+      "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11],
+      "offsets": [2, 1]
     },
     {
       "name": "raiseKnife",
       "prefix": "knife raise xmas0",
-      "offsets": [0, 52]
+      "offsets": [0, 51]
     },
     {
       "name": "idleKnife",
       "prefix": "knife high held xmas0",
-      "offsets": [-99, 52]
+      "offsets": [-112, 51]
     },
     {
       "name": "lowerKnife",
       "prefix": "knife lower xmas0",
-      "offsets": [135, 52]
+      "offsets": [134, 51]
     }
   ]
 }

--- a/preload/data/characters/nene-dark.json
+++ b/preload/data/characters/nene-dark.json
@@ -14,15 +14,13 @@
     {
       "name": "danceRight",
       "prefix": "Nene Idle",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "offsets": [0, 0]
     },
     {
       "name": "combo50",
       "prefix": "combo celebration 1 nene",
-      "offsets": [-120, 50]
+      "offsets": [-124, 51]
     },
     {
       "name": "drop70",
@@ -31,7 +29,7 @@
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
         7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
       ],
-      "offsets": [0, 0]
+      "offsets": [2, -4]
     },
     {
       "name": "laughCutscene",
@@ -40,7 +38,7 @@
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
         7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
       ],
-      "offsets": [0, 0]
+      "offsets": [2, -4]
     },
     {
       "name": "combo200",
@@ -49,22 +47,22 @@
         0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
         6, 6, 6, 6, 6, 6
       ],
-      "offsets": [-50, -25]
+      "offsets": [-46, -11]
     },
     {
       "name": "raiseKnife",
       "prefix": "knife raise",
-      "offsets": [0, 52]
+      "offsets": [0, 51]
     },
     {
       "name": "idleKnife",
       "prefix": "knife high held",
-      "offsets": [-99, 52]
+      "offsets": [-98, 51]
     },
     {
       "name": "lowerKnife",
       "prefix": "knife lower",
-      "offsets": [0, 52]
+      "offsets": [-38, 51]
     }
   ]
 }

--- a/preload/data/characters/nene-pixel.json
+++ b/preload/data/characters/nene-pixel.json
@@ -21,25 +21,25 @@
     {
       "name": "raiseKnife",
       "prefix": "raise",
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     },
     {
       "name": "idleKnife",
       "prefix": "blink",
       "frameIndices": [6, 7],
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     },
     {
       "name": "idleKnifeBlink",
       "prefix": "blink",
       "frameIndices": [0, 1, 2, 3, 4, 5],
-      "offsets": [-19, 10]
+      "offsets": [-21, 10]
     },
     {
       "name": "lowerKnife",
       "prefix": "lower",
       "frameIndices": [0, 1, 2, 3, 4, 5],
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     }
   ]
 }

--- a/preload/data/characters/nene-tankmen.json
+++ b/preload/data/characters/nene-tankmen.json
@@ -23,25 +23,7 @@
     {
       "name": "combo50",
       "prefix": "ComboCheer0",
-      "offsets": [-120, 50]
-    },
-    {
-      "name": "drop70",
-      "prefix": "Laugh0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
-        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
-      ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "laughCutscene",
-      "prefix": "Laugh0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
-        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
-      ],
-      "offsets": [0, 0]
+      "offsets": [-124, 51]
     },
     {
       "name": "combo200",
@@ -50,22 +32,31 @@
         0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
         6, 6, 6, 6, 6, 6
       ],
-      "offsets": [-50, -25]
+      "offsets": [-46, -11]
+    },
+    {
+      "name": "drop70",
+      "prefix": "Laugh0",
+      "frameIndices": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
+        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
+      ],
+      "offsets": [2, -4]
     },
     {
       "name": "raiseKnife",
       "prefix": "KnifeRaise0",
-      "offsets": [0, 52]
+      "offsets": [0, 51]
     },
     {
       "name": "idleKnife",
       "prefix": "KnifeIdle0",
-      "offsets": [-99, 52]
+      "offsets": [-98, 51]
     },
     {
       "name": "lowerKnife",
       "prefix": "KnifeLower0",
-      "offsets": [135, 52]
+      "offsets": [135, 51]
     },
     {
       "name": "hairBlowNormal",
@@ -96,6 +87,15 @@
       "assetPath": "characters/Nene_Hair_Blowing",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
       "offsets": [-79, 51]
+    },
+    {
+      "name": "laughCutscene",
+      "prefix": "Laugh0",
+      "frameIndices": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
+        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
+      ],
+      "offsets": [2, -4]
     }
   ]
 }

--- a/preload/data/characters/nene.json
+++ b/preload/data/characters/nene.json
@@ -23,25 +23,7 @@
     {
       "name": "combo50",
       "prefix": "ComboCheer0",
-      "offsets": [-120, 50]
-    },
-    {
-      "name": "drop70",
-      "prefix": "Laugh0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
-        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
-      ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "laughCutscene",
-      "prefix": "Laugh0",
-      "frameIndices": [
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
-        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
-      ],
-      "offsets": [0, 0]
+      "offsets": [-124, 51]
     },
     {
       "name": "combo200",
@@ -50,22 +32,31 @@
         0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
         6, 6, 6, 6, 6, 6
       ],
-      "offsets": [-50, -25]
+      "offsets": [-46, -11]
+    },
+    {
+      "name": "drop70",
+      "prefix": "Laugh0",
+      "frameIndices": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
+        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
+      ],
+      "offsets": [2, -4]
     },
     {
       "name": "raiseKnife",
       "prefix": "KnifeRaise0",
-      "offsets": [0, 52]
+      "offsets": [0, 51]
     },
     {
       "name": "idleKnife",
       "prefix": "KnifeIdle0",
-      "offsets": [-99, 52]
+      "offsets": [-98, 51]
     },
     {
       "name": "lowerKnife",
       "prefix": "KnifeLower0",
-      "offsets": [135, 52]
+      "offsets": [135, 51]
     },
     {
       "name": "hairBlowNormal",
@@ -96,6 +87,15 @@
       "assetPath": "characters/Nene_Hair_Blowing",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
       "offsets": [-79, 51]
+    },
+    {
+      "name": "laughCutscene",
+      "prefix": "Laugh0",
+      "frameIndices": [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11,
+        7, 8, 9, 10, 11, 7, 8, 9, 10, 11, 7, 8, 9, 10, 11
+      ],
+      "offsets": [2, -4]
     }
   ]
 }

--- a/preload/data/characters/otis-speaker.json
+++ b/preload/data/characters/otis-speaker.json
@@ -14,22 +14,22 @@
     {
       "name": "shoot1",
       "prefix": "shoot back0",
-      "offsets": [0, 13]
+      "offsets": [-2, 13]
     },
     {
       "name": "shoot2",
       "prefix": "shoot back low0",
-      "offsets": [-35, 21]
+      "offsets": [-40, 21]
     },
     {
       "name": "shoot3",
       "prefix": "shoot forward0",
-      "offsets": [238, 96]
+      "offsets": [238, 97]
     },
     {
       "name": "shoot4",
       "prefix": "shoot forward low0",
-      "offsets": [260, 23]
+      "offsets": [263, 23]
     }
   ]
 }

--- a/preload/data/characters/pico-christmas.json
+++ b/preload/data/characters/pico-christmas.json
@@ -19,51 +19,51 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
-      "prefix": "Pico Note Right xmas0",
-      "offsets": [-65, 1]
+      "name": "singLEFT",
+      "prefix": "Pico NOTE LEFT xmas0",
+      "offsets": [66, -15]
     },
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note xmas0",
-      "offsets": [84, -77]
+      "offsets": [46, -88]
     },
     {
       "name": "singUP",
       "prefix": "pico Up note xmas0",
-      "offsets": [31, 28]
+      "offsets": [25, 25]
     },
     {
-      "name": "singLEFT",
-      "prefix": "Pico NOTE LEFT xmas0",
-      "offsets": [90, -11]
+      "name": "singRIGHT",
+      "prefix": "Pico Note Right xmas0",
+      "offsets": [-98, -4]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "Pico NOTE LEFT miss xmas0",
       "looped": false,
-      "offsets": [68, 20],
+      "offsets": [66, 20],
  	"frameIndices": [ 1, 2, 3, 4]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "Pico Down Note MISS xmas0",
       "looped": false,
-      "offsets": [80, -40],
+      "offsets": [46, -45],
  	"frameIndices": [ 1, 2, 3, 4]
     },
     {
       "name": "singUPmiss",
       "prefix": "pico Up note miss xmas0",
       "looped": false,
-      "offsets": [29, 60],
+      "offsets": [21, 62],
  	"frameIndices": [ 1, 2, 3, 4]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "Pico Note Right Miss xmas0",
       "looped": false,
-      "offsets": [-55, 45],
+      "offsets": [-91, 43],
  	"frameIndices": [ 1, 2, 3, 4]
     },
     {
@@ -75,7 +75,7 @@
         21, 22, 23, 24, 25, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
         38, 39, 40, 41, 42, 43, 44, 45, 46, 47
       ],
-      "offsets": [225, 125]
+      "offsets": [162, 98]
     },
     {
       "name": "deathLoop",
@@ -85,7 +85,7 @@
       "frameIndices": [
         48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63
       ],
-      "offsets": [225, 125]
+      "offsets": [162, 98]
     }
   ]
 }

--- a/preload/data/characters/pico-dark.json
+++ b/preload/data/characters/pico-dark.json
@@ -19,64 +19,59 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
-      "prefix": "Pico Note Right0",
-      "offsets": [-50, 1]
+      "name": "singLEFT",
+      "prefix": "Pico NOTE LEFT0",
+      "offsets": [88, -11]
     },
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [84, -77]
+      "offsets": [92, -84]
     },
     {
       "name": "singUP",
       "prefix": "pico Up note0",
-      "offsets": [21, 28]
+      "offsets": [20, 29]
     },
     {
-      "name": "singLEFT",
-      "prefix": "Pico NOTE LEFT0",
-      "offsets": [84, -11]
+      "name": "singRIGHT",
+      "prefix": "Pico Note Right0",
+      "offsets": [-56, 0]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "Pico NOTE LEFT miss",
-      "offsets": [68, 20]
+      "offsets": [89, 24]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "Pico Down Note MISS",
-      "offsets": [80, -40]
+      "offsets": [89, -41]
     },
     {
       "name": "singUPmiss",
       "prefix": "pico Up note miss",
-      "offsets": [29, 70]
+      "offsets": [27, 66]
     },
     {
       "name": "singRIGHTmiss",
       "prefix": "Pico Note Right Miss",
-      "offsets": [-55, 45]
+      "offsets": [-46, 47]
     },
     {
       "name": "hey",
       "prefix": "Pico HEY!!0",
-      "offsets": [36, 0]
+      "offsets": [35, 2]
     },
     {
       "name": "cheer",
       "prefix": "Pico YEAH cheer0",
-      "offsets": [62, 23]
-    },
-    {
-      "name": "burpShit",
-      "prefix": "burpshit",
-      "offsets": [33, -3]
+      "offsets": [69, 16]
     },
     {
       "name": "burpSmile",
       "prefix": "burpsmile",
-      "offsets": [33, -3]
+      "offsets": [37, 0]
     },
     {
       "name": "burpSmileLong",
@@ -87,12 +82,17 @@
         31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
         31, 31, 31, 31, 31, 31
       ],
-      "offsets": [33, -3]
+      "offsets": [37, 0]
+    },
+    {
+      "name": "burpShit",
+      "prefix": "burpshit",
+      "offsets": [37, 0]
     },
     {
       "name": "shit",
       "prefix": "shit",
-      "offsets": [33, -3]
+      "offsets": [1, 1]
     },
     {
       "name": "firstDeath",
@@ -103,7 +103,7 @@
         21, 22, 23, 24, 25, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
         38, 39, 40, 41, 42, 43, 44, 45, 46, 47
       ],
-      "offsets": [225, 125]
+      "offsets": [213, 102]
     },
     {
       "name": "deathLoop",
@@ -113,7 +113,7 @@
       "frameIndices": [
         48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63
       ],
-      "offsets": [225, 125]
+      "offsets": [213, 102]
     }
   ]
 }

--- a/preload/data/characters/pico-holding-nene.json
+++ b/preload/data/characters/pico-holding-nene.json
@@ -21,34 +21,34 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
-      "prefix": "Pico Note Right0",
-      "offsets": [-48, -20]
-    },
-    {
-      "name": "singDOWN",
-      "prefix": "Pico Down Note0",
-      "offsets": [93, -70]
-    },
-    {
-      "name": "singUP",
-      "prefix": "pico Up note0",
-      "offsets": [56, 3]
-    },
-    {
       "name": "singLEFT",
       "prefix": "Pico NOTE LEFT0",
       "offsets": [27, -16]
     },
     {
-      "name": "singRIGHTmiss",
-      "prefix": "note miss right pico nene0",
-      "offsets": [-45, -19]
+      "name": "singDOWN",
+      "prefix": "Pico Down Note0",
+      "offsets": [89, -73]
+    },
+    {
+      "name": "singUP",
+      "prefix": "pico Up note0",
+      "offsets": [56, 2]
+    },
+    {
+      "name": "singRIGHT",
+      "prefix": "Pico Note Right0",
+      "offsets": [-54, -21]
+    },
+    {
+      "name": "singLEFTmiss",
+      "prefix": "note miss left pico nene0",
+      "offsets": [30, -11]
     },
     {
       "name": "singDOWNmiss",
       "prefix": "note miss down pico nene0",
-      "offsets": [95, -74]
+      "offsets": [94, -77]
     },
     {
       "name": "singUPmiss",
@@ -56,14 +56,14 @@
       "offsets": [60, 2]
     },
     {
-      "name": "singLEFTmiss",
-      "prefix": "note miss left pico nene0",
-      "offsets": [28, -11]
+      "name": "singRIGHTmiss",
+      "prefix": "note miss right pico nene0",
+      "offsets": [-48, -19]
     },
     {
       "name": "knifeToss",
       "prefix": "pico nene knife toss0",
-      "offsets": [14, 26]
+      "offsets": [13, 26]
     },
     {
       "name": "laughEnd",

--- a/preload/data/characters/pico-pixel.json
+++ b/preload/data/characters/pico-pixel.json
@@ -35,7 +35,7 @@
     {
       "name": "singUP",
       "prefix": "up0",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singRIGHT",
@@ -55,7 +55,7 @@
     {
       "name": "singUPmiss",
       "prefix": "upmiss0",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singRIGHTmiss",
@@ -65,18 +65,18 @@
     {
       "name": "firstDeath",
       "prefix": "firstDeath0",
-      "offsets": [0, 0]
+      "offsets": [-3, 1]
     },
     {
       "name": "deathLoop",
       "prefix": "deathLoop0",
       "looped": true,
-      "offsets": [0, 0]
+      "offsets": [-3, 1]
     },
     {
       "name": "deathConfirm",
       "prefix": "deathConfirm0",
-      "offsets": [0, 0]
+      "offsets": [-3, 1]
     }
   ]
 }

--- a/preload/data/characters/pico-playable.json
+++ b/preload/data/characters/pico-playable.json
@@ -19,158 +19,90 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
-      "prefix": "Pico Note Right0",
-      "offsets": [-50, 1]
+      "name": "singLEFT",
+      "prefix": "Pico NOTE LEFT0",
+      "offsets": [88, -11]
     },
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [84, -77]
+      "offsets": [92, -84]
     },
     {
       "name": "singUP",
       "prefix": "pico Up note0",
-      "offsets": [21, 28]
+      "offsets": [20, 29]
     },
     {
-      "name": "singLEFT",
-      "prefix": "Pico NOTE LEFT0",
-      "offsets": [84, -11]
-    },
-    {
-      "name": "singRIGHT-censor",
-      "prefix": "pico swear right",
-      "assetPath": "characters/Pico_Censored",
-      "offsets": [-50, 1]
-    },
-    {
-      "name": "singDOWN-censor",
-      "prefix": "pico swear down",
-      "assetPath": "characters/Pico_Censored",
-      "offsets": [84, -77]
-    },
-    {
-      "name": "singUP-censor",
-      "prefix": "pico swear up",
-      "assetPath": "characters/Pico_Censored",
-      "offsets": [21, 28]
-    },
-    {
-      "name": "singLEFT-censor",
-      "prefix": "pico swear left",
-      "assetPath": "characters/Pico_Censored",
-      "offsets": [84, -11]
+      "name": "singRIGHT",
+      "prefix": "Pico Note Right0",
+      "offsets": [-56, 0]
     },
     {
       "name": "singLEFTmiss",
       "assetPath": "characters/Pico_Playable",
       "prefix": "Pico Left Note MISS",
-      "offsets": [68, 20]
+      "offsets": [89, 24]
     },
     {
       "name": "singDOWNmiss",
       "assetPath": "characters/Pico_Playable",
       "prefix": "Pico Down Note MISS",
-      "offsets": [80, -40]
+      "offsets": [89, -41]
     },
     {
       "name": "singUPmiss",
       "assetPath": "characters/Pico_Playable",
       "prefix": "Pico Up Note MISS",
-      "offsets": [29, 70]
+      "offsets": [27, 66]
     },
     {
       "name": "singRIGHTmiss",
       "assetPath": "characters/Pico_Playable",
       "prefix": "Pico Right Note MISS",
-      "offsets": [-55, 45]
+      "offsets": [-46, 47]
     },
     {
-      "name": "shootMISS",
-      "assetPath": "characters/Pico_Shooting",
-      "prefix": "Pico Hit Can0",
-      "offsets": [0, 0]
+      "name": "singLEFT-censor",
+      "prefix": "pico swear left",
+      "assetPath": "characters/Pico_Censored",
+      "offsets": [88, -11]
     },
     {
-      "name": "firstDeath",
-      "prefix": "Pico Death Stab",
-      "assetPath": "characters/Pico_Death",
-      "frameIndices": [
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-        38, 39, 40, 41, 42, 43, 44, 45, 46, 47
-      ],
-      "offsets": [225, 125]
+      "name": "singDOWN-censor",
+      "prefix": "pico swear down",
+      "assetPath": "characters/Pico_Censored",
+      "offsets": [92, -84]
     },
     {
-      "name": "firstDeathExplosion",
-      "prefix": "Pico Idle Dance",
-      "offsets": [225, 125]
+      "name": "singUP-censor",
+      "prefix": "pico swear up",
+      "assetPath": "characters/Pico_Censored",
+      "offsets": [20, 29]
     },
     {
-      "name": "deathLoop",
-      "prefix": "Pico Death Stab",
-      "looped": true,
-      "assetPath": "characters/Pico_Death",
-      "frameIndices": [
-        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63
-      ],
-      "offsets": [225, 125]
+      "name": "singRIGHT-censor",
+      "prefix": "pico swear right",
+      "assetPath": "characters/Pico_Censored",
+      "offsets": [-56, 0]
     },
     {
       "name": "hey",
       "prefix": "Pico HEY!!0",
       "assetPath": "characters/pico-cheer",
-      "offsets": [36, 0]
+      "offsets": [35, 2]
     },
     {
       "name": "cheer",
       "prefix": "Pico YEAH cheer0",
       "assetPath": "characters/pico-yeah",
-      "offsets": [62, 23]
-    },
-    {
-      "name": "cock",
-      "assetPath": "characters/Pico_Shooting",
-      "prefix": "Pico Reload0",
-      "offsets": [30, -8]
-    },
-    {
-      "name": "shoot",
-      "assetPath": "characters/Pico_Shooting",
-      "prefix": "Pico Shoot Hip Full0",
-      "offsets": [330, 232]
-    },
-    {
-      "name": "intro1",
-      "assetPath": "characters/Pico_Intro",
-      "prefix": "Pico Gets Pissed0",
-      "offsets": [60, 0]
-    },
-    {
-      "name": "cockCutscene",
-      "assetPath": "characters/Pico_Intro",
-      "prefix": "cutscene cock0",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "intro2",
-      "assetPath": "characters/Pico_Intro",
-      "prefix": "shoot and return0",
-      "offsets": [260, 230]
-    },
-    {
-      "name": "burpShit",
-      "assetPath": "characters/Pico_Burps",
-      "prefix": "burpshit",
-      "offsets": [33, -3]
+      "offsets": [69, 16]
     },
     {
       "name": "burpSmile",
       "assetPath": "characters/Pico_Burps",
       "prefix": "burpsmile",
-      "offsets": [33, -3]
+      "offsets": [37, 0]
     },
     {
       "name": "burpSmileLong",
@@ -182,13 +114,81 @@
         31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31,
         31, 31, 31, 31, 31, 31
       ],
-      "offsets": [33, -3]
+      "offsets": [37, 0]
+    },
+    {
+      "name": "burpShit",
+      "assetPath": "characters/Pico_Burps",
+      "prefix": "burpshit",
+      "offsets": [37, 0]
     },
     {
       "name": "shit",
       "assetPath": "characters/Pico_Burps",
       "prefix": "shit",
-      "offsets": [0, -3]
+      "offsets": [1, 1]
+    },
+    {
+      "name": "cock",
+      "assetPath": "characters/Pico_Shooting",
+      "prefix": "Pico Reload0",
+      "offsets": [-50, -9]
+    },
+    {
+      "name": "shoot",
+      "assetPath": "characters/Pico_Shooting",
+      "prefix": "Pico Shoot Hip Full0",
+      "offsets": [253, 232]
+    },
+    {
+      "name": "shootMISS",
+      "assetPath": "characters/Pico_Shooting",
+      "prefix": "Pico Hit Can0",
+      "offsets": [-24, -6]
+    },
+    {
+      "name": "firstDeath",
+      "prefix": "Pico Death Stab",
+      "assetPath": "characters/Pico_Death",
+      "frameIndices": [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        21, 22, 23, 24, 25, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+        38, 39, 40, 41, 42, 43, 44, 45, 46, 47
+      ],
+      "offsets": [213, 102]
+    },
+    {
+      "name": "firstDeathExplosion",
+      "prefix": "Pico Idle Dance",
+      "offsets": [213, 102]
+    },
+    {
+      "name": "deathLoop",
+      "prefix": "Pico Death Stab",
+      "looped": true,
+      "assetPath": "characters/Pico_Death",
+      "frameIndices": [
+        48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63
+      ],
+      "offsets": [213, 102]
+    },
+    {
+      "name": "intro1",
+      "assetPath": "characters/Pico_Intro",
+      "prefix": "Pico Gets Pissed0",
+      "offsets": [57, 0]
+    },
+    {
+      "name": "cockCutscene",
+      "assetPath": "characters/Pico_Intro",
+      "prefix": "cutscene cock0",
+      "offsets": [-55, 10]
+    },
+    {
+      "name": "intro2",
+      "assetPath": "characters/Pico_Intro",
+      "prefix": "shoot and return0",
+      "offsets": [252, 231]
     }
   ]
 }

--- a/preload/data/characters/pico-speaker.json
+++ b/preload/data/characters/pico-speaker.json
@@ -28,36 +28,36 @@
     {
       "name": "shoot2",
       "prefix": "Pico shoot 2",
-      "offsets": [-1, -128]
+      "offsets": [0, -128]
     },
     {
       "name": "shoot2-hold",
       "prefix": "Pico shoot 2",
-      "offsets": [-1, -128],
+      "offsets": [0, -128],
       "looped": true,
       "frameIndices": [56, 57, 58, 59]
     },
     {
       "name": "shoot3",
       "prefix": "Pico shoot 3",
-      "offsets": [412, -64]
+      "offsets": [413, -64]
     },
     {
       "name": "shoot3-hold",
       "prefix": "Pico shoot 3",
-      "offsets": [412, -64],
+      "offsets": [413, -64],
       "looped": true,
       "frameIndices": [49, 50, 51, 52]
     },
     {
       "name": "shoot4",
       "prefix": "Pico shoot 4",
-      "offsets": [439, -19]
+      "offsets": [440, -19]
     },
     {
       "name": "shoot4-hold",
       "prefix": "Pico shoot 4",
-      "offsets": [439, -19],
+      "offsets": [440, -19],
       "looped": true,
       "frameIndices": [49, 50, 51, 52]
     }

--- a/preload/data/characters/pico.json
+++ b/preload/data/characters/pico.json
@@ -10,24 +10,24 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
-      "prefix": "Pico NOTE LEFT0",
-      "offsets": [-86, -10]
+      "name": "singLEFT",
+      "prefix": "Pico Note Right0",
+      "offsets": [60, 1]
     },
     {
       "name": "singDOWN",
       "prefix": "Pico Down Note0",
-      "offsets": [-37, -82]
+      "offsets": [-38, -84]
     },
     {
       "name": "singUP",
       "prefix": "pico Up note0",
-      "offsets": [-32, 28]
+      "offsets": [-39, 29]
     },
     {
-      "name": "singLEFT",
-      "prefix": "Pico Note Right0",
-      "offsets": [61, 2]
+      "name": "singRIGHT",
+      "prefix": "Pico NOTE LEFT0",
+      "offsets": [-86, -11]
     }
   ]
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
Divided into parts of #79

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
One issue that I mentioned in FunkinCrew/Funkin/issues/3105

<!-- Briefly describe the issue(s) fixed. -->
## Description
1. Almost all offsets for each animation for Pico, Darnell, Nene, and Otis (except for those using spritemaps) have been improved.
2. Changed the order of some animations in the `.json` files to make it a little more intuitive. It follows this order:
   - Idle/dance
   - Sing
   - Sing miss
   - Sing-alts (alt, censor, etc.)
   - Hey, cheer
   - Other animations during songs
   - Death animations
   - Cutscene animations
3. Fixed `pico-dark.json` sing-miss animations because the prefixes were causing it to use `pico-playable` animations.
4. Removed from `nene-tankmen.json` `"hairBlowing"` animations because they probably won't be used.

**Potential changes I didn't make in case they break something:**
1. Removed `"firstDeathExplosion"` from `pico-playable.json` because it has a prefix: "Pico Idle Dance".
2. Removed `"firstDeath"` from `pico-holding-nene.json` because it's an animation with just an empty name and prefix.

I used the foot that was pointing towards the camera as a reference in most animations, in others (like `pico.json` `"singUP"`) I used the other one.
If you notice any errors or changes you don't like, let me know so I can change them.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
If you need them I can make them.