### PR TITLE
Improved offsets for various characters

### DIFF
--- a/preload/data/characters/dad.json
+++ b/preload/data/characters/dad.json
@@ -19,50 +19,43 @@
     {
       "name": "singLEFT",
       "prefix": "singLEFT",
-      "offsets": [-10, 10]
+      "offsets": [-6, 10]
     },
     {
       "name": "singLEFT-hold",
       "prefix": "singLEFT",
       "looped": true,
       "frameIndices": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      "offsets": [-10, 10]
+      "offsets": [-6, 10]
     },
     {
       "name": "singDOWN",
       "prefix": "singDOWN",
-      "offsets": [0, -30]
-    },
-    {
-      "name": "singDOWN-hold",
-      "prefix": "singDOWN",
-      "looped": true,
-      "frameIndices": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      "offsets": [0, -30]
+      "offsets": [-1, -30]
     },
     {
       "name": "singUP",
       "prefix": "singUP",
-      "offsets": [-6, 50]
+      "offsets": [-10, 51]
     },
     {
       "name": "singUP-hold",
       "prefix": "singUP",
       "looped": true,
       "frameIndices": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      "offsets": [-6, 50]
+      "offsets": [-10, 51]
     },
     {
       "name": "singRIGHT",
       "prefix": "singRIGHT",
-      "offsets": [0, 27]
+      "offsets": [-6, 27]
     },
     {
       "name": "singRIGHT-hold",
       "prefix": "singRIGHT",
       "looped": true,
       "frameIndices": [3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-      "offsets": [0, 27]
+      "offsets": [-6, 27]
     }
   ]
 }

--- a/preload/data/characters/mom-car.json
+++ b/preload/data/characters/mom-car.json
@@ -23,50 +23,50 @@
     {
       "name": "singLEFT",
       "prefix": "Mom Left Pose0",
-      "offsets": [250, -23]
+      "offsets": [250, -21]
     },
     {
       "name": "singLEFT-hold",
       "prefix": "Mom Left Pose0",
       "looped": true,
       "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9],
-      "offsets": [250, -23]
+      "offsets": [250, -21]
     },
     {
       "name": "singDOWN",
       "prefix": "MOM DOWN POSE0",
-      "offsets": [20, -160]
+      "offsets": [-12, -160]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "MOM DOWN POSE0",
       "looped": true,
       "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [20, -160]
+      "offsets": [-12, -160]
     },
     {
       "name": "singUP",
       "prefix": "Mom Up Pose0",
-      "offsets": [14, 71]
+      "offsets": [-5, 81]
     },
     {
       "name": "singUP-hold",
       "prefix": "Mom Up Pose0",
       "looped": true,
       "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [14, 71]
+      "offsets": [-5, 81]
     },
     {
       "name": "singRIGHT",
-      "prefix": "Mom Pose Left0",
-      "offsets": [10, -60]
+      "prefix": "Mom Right Pose0",
+      "offsets": [-34, -52]
     },
     {
       "name": "singRIGHT-hold",
-      "prefix": "Mom Pose Left0",
+      "prefix": "Mom Right Pose0",
       "looped": true,
       "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9],
-      "offsets": [10, -60]
+      "offsets": [-34, -52]
     }
   ]
 }

--- a/preload/data/characters/monster-christmas.json
+++ b/preload/data/characters/monster-christmas.json
@@ -14,62 +14,57 @@
     {
       "name": "idle-hold",
       "prefix": "monster idle",
-      "looped": true,
       "frameIndices": [12, 13, 14],
+      "looped": true,
       "offsets": [0, 0]
     },
     {
-      "name": "singRIGHT",
+      "name": "singLEFT",
       "prefix": "Monster left note",
-      "offsets": [-30, 0]
+      "offsets": [-35, 12]
     },
     {
-      "name": "singRIGHT-hold",
+      "name": "singLEFT-hold",
       "prefix": "Monster left note",
-      "looped": true,
       "frameIndices": [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
-      "offsets": [-30, 0]
+      "looped": true,
+      "offsets": [-35, 12]
     },
     {
       "name": "singDOWN",
       "prefix": "monster down",
-      "offsets": [-40, -94]
+      "offsets": [-47, -93]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "monster down",
+      "frameIndices": [7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "looped": true,
-      "frameIndices": [
-        7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-        26, 27, 28, 29
-      ],
-      "offsets": [-40, -94]
+      "offsets": [-47, -93]
     },
     {
       "name": "singUP",
       "prefix": "monster up note",
-      "offsets": [-20, 50]
+      "offsets": [-28, 57]
     },
     {
       "name": "singUP-hold",
       "prefix": "monster up note",
+      "frameIndices": [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
       "looped": true,
-      "frameIndices": [
-        8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23
-      ],
-      "offsets": [-20, 50]
+      "offsets": [-28, 57]
     },
     {
-      "name": "singLEFT",
+      "name": "singRIGHT",
       "prefix": "Monster Right note",
-      "offsets": [-51, 0]
+      "offsets": [-45, 8]
     },
     {
-      "name": "singLEFT-hold",
+      "name": "singRIGHT-hold",
       "prefix": "Monster Right note",
-      "looped": true,
       "frameIndices": [6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-51, 0]
+      "looped": true,
+      "offsets": [-45, 8]
     }
   ]
 }

--- a/preload/data/characters/monster.json
+++ b/preload/data/characters/monster.json
@@ -17,59 +17,51 @@
     },
     {
       "name": "singLEFT",
-      "prefix": "Monster Right note",
-      "offsets": [-30, 20]
+      "prefix": "Monster left note",
+      "offsets": [-35, 10]
     },
     {
       "name": "singLEFT-hold",
-      "prefix": "Monster Right note",
+      "prefix": "Monster left note",
       "looped": true,
-      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-30, 20]
+      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+      "offsets": [-35, 10]
     },
     {
       "name": "singDOWN",
       "prefix": "monster down",
-      "offsets": [-50, -80]
+      "offsets": [-48, -87]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "monster down",
       "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [-50, -80]
+      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
+      "offsets": [-48, -87]
     },
     {
       "name": "singUP",
       "prefix": "monster up note",
-      "offsets": [-20, 94]
+      "offsets": [-28, 91]
     },
     {
       "name": "singUP-hold",
       "prefix": "monster up note",
       "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-        22, 23
-      ],
-      "offsets": [-20, 94]
+      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+      "offsets": [-28, 91]
     },
     {
       "name": "singRIGHT",
-      "prefix": "Monster left note",
-      "offsets": [-51, 30]
+      "prefix": "Monster Right note",
+      "offsets": [-45, 14]
     },
     {
       "name": "singRIGHT-hold",
-      "prefix": "Monster left note",
+      "prefix": "Monster Right note",
       "looped": true,
-      "frameIndices": [
-        2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19
-      ],
-      "offsets": [-51, 30]
+      "frameIndices": [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+      "offsets": [-45, 14]
     }
   ]
 }

--- a/preload/data/characters/parents-christmas.json
+++ b/preload/data/characters/parents-christmas.json
@@ -18,98 +18,98 @@
     {
       "name": "singLEFT",
       "prefix": "Parent Left Note Dad",
-      "offsets": [-30, 16]
+      "offsets": [-25, 20]
     },
     {
       "name": "singLEFT-hold",
       "prefix": "Parent Left Note Dad",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-      "offsets": [-30, 16]
+      "offsets": [-25, 20]
     },
     {
       "name": "singDOWN",
       "prefix": "Parent Down Note Dad",
-      "offsets": [-31, -29]
+      "offsets": [-34, -23]
     },
     {
       "name": "singDOWN-hold",
       "prefix": "Parent Down Note Dad",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-31, -29]
+      "offsets": [-34, -23]
     },
     {
       "name": "singUP",
       "prefix": "Parent Up Note Dad",
-      "offsets": [-47, 24]
+      "offsets": [-45, 26]
     },
     {
       "name": "singUP-hold",
       "prefix": "Parent Up Note Dad",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-      "offsets": [-47, 24]
+      "offsets": [-45, 26]
     },
     {
       "name": "singRIGHT",
       "prefix": "Parent Right Note Dad",
-      "offsets": [-1, -23]
+      "offsets": [-7, -20]
     },
     {
       "name": "singRIGHT-hold",
       "prefix": "Parent Right Note Dad",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
-      "offsets": [-1, -23]
+      "offsets": [-7, -20]
     },
     {
       "name": "singLEFT-alt",
       "prefix": "Parent Left Note Mom",
-      "offsets": [-30, 15]
+      "offsets": [-25, 19]
     },
     {
       "name": "singLEFT-alt-hold",
       "prefix": "Parent Left Note Mom",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-30, 15]
+      "offsets": [-25, 19]
     },
     {
       "name": "singDOWN-alt",
       "prefix": "Parent Down Note Mom",
-      "offsets": [-30, -27]
+      "offsets": [-34, -23]
     },
     {
       "name": "singDOWN-alt-hold",
       "prefix": "Parent Down Note Mom",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-30, -27]
+      "offsets": [-34, -23]
     },
     {
       "name": "singUP-alt",
       "prefix": "Parent Up Note Mom",
-      "offsets": [-47, 24]
+      "offsets": [-44, 29]
     },
     {
       "name": "singUP-alt-hold",
       "prefix": "Parent Up Note Mom",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
-      "offsets": [-47, 24]
+      "offsets": [-44, 29]
     },
     {
       "name": "singRIGHT-alt",
       "prefix": "Parent Right Note Mom",
-      "offsets": [-1, -24]
+      "offsets": [-7, -19]
     },
     {
       "name": "singRIGHT-alt-hold",
       "prefix": "Parent Right Note Mom",
       "looped": true,
       "frameIndices": [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
-      "offsets": [-1, -24]
+      "offsets": [-7, -19]
     }
   ]
 }

--- a/preload/data/characters/senpai-angry.json
+++ b/preload/data/characters/senpai-angry.json
@@ -18,22 +18,22 @@
     {
       "name": "singLEFT",
       "prefix": "Angry Senpai LEFT NOTE instance 10",
-      "offsets": [6.6, 0]
+      "offsets": [4, 1]
     },
     {
       "name": "singDOWN",
       "prefix": "Angry Senpai DOWN NOTE instance 10",
-      "offsets": [2.33, 0]
+      "offsets": [1, 1]
     },
     {
       "name": "singUP",
       "prefix": "Angry Senpai UP NOTE instance 10",
-      "offsets": [0.83, 6.16]
+      "offsets": [1, 6]
     },
     {
       "name": "singRIGHT",
       "prefix": "Angry Senpai RIGHT NOTE instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     }
   ]
 }

--- a/preload/data/characters/senpai.json
+++ b/preload/data/characters/senpai.json
@@ -18,17 +18,17 @@
     {
       "name": "singLEFT",
       "prefix": "SENPAI LEFT NOTE instance 10",
-      "offsets": [6.6, 0]
+      "offsets": [5, 0]
     },
     {
       "name": "singDOWN",
       "prefix": "SENPAI DOWN NOTE instance 10",
-      "offsets": [2.33, 0]
+      "offsets": [2, 0]
     },
     {
       "name": "singUP",
       "prefix": "SENPAI UP NOTE instance 10",
-      "offsets": [0.83, 6.16]
+      "offsets": [2, 6]
     },
     {
       "name": "singRIGHT",

--- a/preload/data/characters/spirit.json
+++ b/preload/data/characters/spirit.json
@@ -6,36 +6,33 @@
   "renderType": "packer",
   "isPixel": true,
   "scale": 6,
+  "offsets": [31, 40],
+  "cameraOffsets": [-31, -40],
   "animations": [
     {
       "name": "idle",
       "prefix": "idle spirit_",
-      "frameIndices": [],
-      "offsets": [-36.66, -46.66]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "left_",
-      "frameIndices": [],
-      "offsets": [-33.33, -46.66]
+      "offsets": [2, -2]
     },
     {
       "name": "singDOWN",
       "prefix": "spirit down_",
-      "frameIndices": [],
-      "offsets": [28.33, 18.33]
+      "offsets": [65, 64]
     },
     {
       "name": "singUP",
       "prefix": "up_",
-      "frameIndices": [],
-      "offsets": [-36.66, -40.0]
+      "offsets": [0, 9]
     },
     {
       "name": "singRIGHT",
       "prefix": "right_",
-      "frameIndices": [],
-      "offsets": [-36.66, -46.66]
+      "offsets": [-3, 1]
     }
   ]
 }

--- a/preload/data/characters/spooky-dark.json
+++ b/preload/data/characters/spooky-dark.json
@@ -27,27 +27,27 @@
     {
       "name": "singLEFT",
       "prefix": "SingLEFT",
-      "offsets": [130, -10]
+      "offsets": [114, -15]
     },
     {
       "name": "singDOWN",
       "prefix": "SingDOWN",
-      "offsets": [-50, -130]
+      "offsets": [-29, -145]
     },
     {
       "name": "singUP",
       "prefix": "SingUP",
-      "offsets": [-20, 26]
+      "offsets": [-24, 25]
     },
     {
       "name": "singRIGHT",
       "prefix": "SingRIGHT",
-      "offsets": [-130, -14]
+      "offsets": [-151, -13]
     },
     {
       "name": "cheer",
       "prefix": "Cheer",
-      "offsets": [0, 0]
+      "offsets": [45, 30]
     }
   ]
 }

--- a/preload/data/characters/spooky.json
+++ b/preload/data/characters/spooky.json
@@ -22,27 +22,27 @@
     {
       "name": "singLEFT",
       "prefix": "SingLEFT",
-      "offsets": [130, -10]
+      "offsets": [114, -15]
     },
     {
       "name": "singDOWN",
       "prefix": "SingDOWN",
-      "offsets": [-50, -130]
+      "offsets": [-29, -145]
     },
     {
       "name": "singUP",
       "prefix": "SingUP",
-      "offsets": [-20, 26]
+      "offsets": [-24, 25]
     },
     {
       "name": "singRIGHT",
       "prefix": "SingRIGHT",
-      "offsets": [-130, -14]
+      "offsets": [-151, -13]
     },
     {
       "name": "cheer",
       "prefix": "Cheer",
-      "offsets": [0, 0]
+      "offsets": [45, 30]
     }
   ]
 }

--- a/preload/data/characters/tankman-bloody.json
+++ b/preload/data/characters/tankman-bloody.json
@@ -29,7 +29,7 @@
     },
     {
       "flipY": false,
-      "offsets": [90, -13],
+      "offsets": [92, -13],
       "frameRate": 24,
       "prefix": "Tankman Right Note instance 1",
       "flipX": false,
@@ -37,7 +37,7 @@
     },
     {
       "flipY": false,
-      "offsets": [63, -105],
+      "offsets": [58, -104],
       "frameRate": 24,
       "prefix": "Tankman DOWN note instance 1",
       "flipX": false,
@@ -45,7 +45,7 @@
     },
     {
       "flipY": false,
-      "offsets": [48, 54],
+      "offsets": [55, 49],
       "frameRate": 24,
       "prefix": "Tankman UP note instance 1",
       "flipX": false,
@@ -53,7 +53,7 @@
     },
     {
       "flipY": false,
-      "offsets": [-22, -28],
+      "offsets": [-21, -31],
       "frameRate": 24,
       "prefix": "Tankman Note Left instance 1",
       "flipX": false,
@@ -61,7 +61,15 @@
     },
     {
       "flipY": false,
-      "offsets": [-2, 15],
+      "offsets": [-15, -9],
+      "frameRate": 24,
+      "prefix": "TANKMAN UGH instance 1",
+      "flipX": false,
+      "name": "ugh"
+    },
+    {
+      "flipY": false,
+      "offsets": [2, 16],
       "frameRate": 24,
       "prefix": "PRETTY GOOD tankman instance 1",
       "flipX": false,
@@ -69,11 +77,12 @@
     },
     {
       "flipY": false,
-      "offsets": [-16, -9],
+      "offsets": [110, 119],
       "frameRate": 24,
-      "prefix": "TANKMAN UGH instance 1",
+      "prefix": "redheads anim0",
       "flipX": false,
-      "name": "ugh"
+      "assetPath": "characters/tankmanCaptainBloody",
+      "name": "redheadsAnim"
     },
     {
       "flipY": false,
@@ -95,7 +104,7 @@
     },
     {
       "flipY": false,
-      "offsets": [62, -105],
+      "offsets": [58, -104],
       "frameRate": 24,
       "prefix": "Tankman DOWN note bloody0",
       "flipX": false,
@@ -104,7 +113,7 @@
     },
     {
       "flipY": false,
-      "offsets": [47, 165],
+      "offsets": [55, 159],
       "frameRate": 24,
       "prefix": "Tankman UP note bloody0",
       "flipX": false,
@@ -113,7 +122,7 @@
     },
     {
       "flipY": false,
-      "offsets": [-23, 17],
+      "offsets": [-21, 15],
       "frameRate": 24,
       "prefix": "Tankman Note Left bloody0",
       "flipX": false,
@@ -122,16 +131,7 @@
     },
     {
       "flipY": false,
-      "offsets": [110, 117],
-      "frameRate": 24,
-      "prefix": "redheads anim0",
-      "flipX": false,
-      "assetPath": "characters/tankmanCaptainBloody",
-      "name": "redheadsAnim"
-    },
-    {
-      "flipY": false,
-      "offsets": [0, 90],
+      "offsets": [2, 90],
       "frameRate": 24,
       "prefix": "pretty good anim0",
       "assetPath": "characters/tankmanCaptainBloody",

--- a/preload/data/characters/tankman.json
+++ b/preload/data/characters/tankman.json
@@ -29,7 +29,7 @@
     },
     {
       "flipY": false,
-      "offsets": [90, -13],
+      "offsets": [92, -13],
       "frameRate": 24,
       "prefix": "Tankman Right Note instance 1",
       "flipX": false,
@@ -37,7 +37,7 @@
     },
     {
       "flipY": false,
-      "offsets": [63,-105],
+      "offsets": [58, -104],
       "frameRate": 24,
       "prefix": "Tankman DOWN note instance 1",
       "flipX": false,
@@ -45,7 +45,7 @@
     },
     {
       "flipY": false,
-      "offsets": [48,54],
+      "offsets": [55, 49],
       "frameRate": 24,
       "prefix": "Tankman UP note instance 1",
       "flipX": false,
@@ -53,7 +53,7 @@
     },
     {
       "flipY": false,
-      "offsets": [-22,-28],
+      "offsets": [-21, -31],
       "frameRate": 24,
       "prefix": "Tankman Note Left instance 1",
       "flipX": false,
@@ -61,15 +61,7 @@
     },
     {
       "flipY": false,
-      "offsets": [-2, 15],
-      "frameRate": 24,
-      "prefix": "PRETTY GOOD tankman instance 1",
-      "flipX": false,
-      "name": "hehPrettyGood"
-    },
-    {
-      "flipY": false,
-      "offsets": [-16, -9],
+      "offsets": [-15, -9],
       "frameRate": 24,
       "prefix": "TANKMAN UGH instance 1",
       "flipX": false,
@@ -77,7 +69,24 @@
     },
     {
       "flipY": false,
-      "offsets": [-18, 10],
+      "offsets": [2, 16],
+      "frameRate": 24,
+      "prefix": "PRETTY GOOD tankman instance 1",
+      "flipX": false,
+      "name": "hehPrettyGood"
+    },
+    {
+      "flipY": false,
+      "offsets": [52, 1],
+      "frameRate": 24,
+      "prefix": "tankman ARGH",
+      "assetPath": "characters/tankmanPico",
+      "flipX": true,
+      "name": "augh"
+    },
+    {
+      "flipY": false,
+      "offsets": [-26, 12],
       "frameRate": 24,
       "prefix": "tankman laugh",
       "flipX": true,
@@ -86,21 +95,12 @@
     },
     {
       "flipY": false,
-      "offsets": [90, -9],
+      "offsets": [86, -15],
       "frameRate": 24,
       "prefix": "tankman beat it",
       "assetPath": "characters/tankmanPico",
       "flipX": true,
       "name": "beat it"
-    },
-    {
-      "flipY": false,
-      "offsets": [52, -6],
-      "frameRate": 24,
-      "prefix": "tankman ARGH",
-      "assetPath": "characters/tankmanPico",
-      "flipX": true,
-      "name": "augh"
     }
   ]
 }

--- a/shared/images/characters/momCar.xml
+++ b/shared/images/characters/momCar.xml
@@ -39,16 +39,16 @@
 	<SubTexture name="Mom Left Pose0007" x="3149" y="824" width="568" height="806" frameX="-2" frameY="-4" frameWidth="570" frameHeight="810" />
 	<SubTexture name="Mom Left Pose0008" x="3727" y="824" width="570" height="810" />
 	<SubTexture name="Mom Left Pose0009" x="4307" y="824" width="566" height="806" frameX="-4" frameY="-4" frameWidth="570" frameHeight="810" />
-	<SubTexture name="Mom Pose Left0000" x="4883" y="824" width="662" height="762" frameX="0" frameY="0" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0001" x="5555" y="824" width="672" height="762" />
-	<SubTexture name="Mom Pose Left0002" x="6237" y="824" width="648" height="745" frameX="0" frameY="-17" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0003" x="6895" y="824" width="658" height="743" frameX="0" frameY="-19" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0004" x="0" y="1648" width="658" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0005" x="668" y="1648" width="662" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0006" x="1340" y="1648" width="648" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0007" x="1998" y="1648" width="658" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0008" x="0" y="1648" width="658" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
-	<SubTexture name="Mom Pose Left0009" x="668" y="1648" width="662" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0000" x="4883" y="824" width="662" height="762" frameX="0" frameY="0" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0001" x="5555" y="824" width="672" height="762" />
+	<SubTexture name="Mom Right Pose0002" x="6237" y="824" width="648" height="745" frameX="0" frameY="-17" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0003" x="6895" y="824" width="658" height="743" frameX="0" frameY="-19" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0004" x="0" y="1648" width="658" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0005" x="668" y="1648" width="662" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0006" x="1340" y="1648" width="648" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0007" x="1998" y="1648" width="658" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0008" x="0" y="1648" width="658" height="749" frameX="0" frameY="-13" frameWidth="672" frameHeight="762" />
+	<SubTexture name="Mom Right Pose0009" x="668" y="1648" width="662" height="747" frameX="0" frameY="-15" frameWidth="672" frameHeight="762" />
 	<SubTexture name="Mom Up Pose0000" x="2666" y="1648" width="455" height="840" frameX="0" frameY="-14" frameWidth="473" frameHeight="861" />
 	<SubTexture name="Mom Up Pose0001" x="3131" y="1648" width="451" height="838" frameX="-10" frameY="-16" frameWidth="473" frameHeight="861" />
 	<SubTexture name="Mom Up Pose0002" x="3592" y="1648" width="455" height="860" frameX="-6" frameY="-1" frameWidth="473" frameHeight="861" />


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
Divided into parts of #79
Part 1: #237 
Part 2: #238
Part 3: current

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
One issue that I mentioned in FunkinCrew/Funkin/issues/3105

<!-- Briefly describe the issue(s) fixed. -->
## Description
1. Improved almost all offsets for some characters animations (except for those using spritemaps).
2. Changed the order of some animations in the `.json` files to make it a little more intuitive. It follows this order:
   - Idle/dance
   - Sing
   - Sing miss
   - Sing-alts (alt, censor, etc.)
   - Hey, cheer
   - Other animations during songs
   - Death animations
   - Cutscene animations
3. Removed `"singDOWN-Hold"` from `dad.json`, as it is used for his eye animation, but in `"singDOWN"` his eyes are not open.
4. Fixed `"SingRIGHT"` animations in `momCar.json` and its `.xml`.
5. `"SingLEFT"` and `"SingRIGHT"` animations in `monster.json` and `monster-christmas.json` have been returned to how they appear in their `.xml`.

If you notice any errors or changes you don't like, let me know so I can change them.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
If you need them I can make them.