### PR TITLE
[OPTIMIZATION] Fix background Tankmen causing a stutter

### DIFF
--- a/preload/scripts/stages/props/TankmanSpriteGroup.hxc
+++ b/preload/scripts/stages/props/TankmanSpriteGroup.hxc
@@ -3,6 +3,7 @@ import flixel.FlxSprite;
 import flixel.group.FlxTypedSpriteGroup;
 import flixel.util.FlxSort;
 import funkin.Conductor;
+import funkin.FunkinMemory;
 import funkin.modding.base.ScriptedFunkinSprite;
 import funkin.play.PlayState;
 import Lambda;
@@ -25,6 +26,9 @@ class TankmanSpriteGroup extends FlxTypedSpriteGroup
 
     this.isErect = (erect != null) ? erect : false;
     trace('Initializing TankmanSpriteGroup... ' + (this.isErect ? ' (erect)' : ' (base)'));
+
+    // Precache the Tankman sprite.
+    FunkinMemory.cacheTexture(Paths.image('tankmanKilled1', 'week7'));
   }
 
   public function isValid():Bool


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
N/A
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A (or none that I can recall...)
<!-- Briefly describe the issue(s) fixed. -->
## Description
Basically pre-caches the sprite when their sprite group is created so that it doesn't cause a stutter when it first generates a Tankman.

The caching system definitely needs to be looked into on why it's not being able to cache all images though, but this will suffice for now.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
