### PR TITLE
[BUGFIX] Fixes for BF, Pico and Mom in Story Mode

### DIFF
--- a/preload/data/levels/tutorial.json
+++ b/preload/data/levels/tutorial.json
@@ -37,6 +37,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week1.json
+++ b/preload/data/levels/week1.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week2.json
+++ b/preload/data/levels/week2.json
@@ -33,6 +33,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week3.json
+++ b/preload/data/levels/week3.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week4.json
+++ b/preload/data/levels/week4.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week5.json
+++ b/preload/data/levels/week5.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week6.json
+++ b/preload/data/levels/week6.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/week7.json
+++ b/preload/data/levels/week7.json
@@ -28,6 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
+          "offsets": [-1, 2],
           "frameRate": 24
         }
       ]

--- a/preload/data/levels/weekend1.json
+++ b/preload/data/levels/weekend1.json
@@ -28,7 +28,7 @@
         {
           "name": "confirm",
           "prefix": "confirm0",
-          "offsets": [30, 0],
+          "offsets": [27, 2],
           "frameRate": 24
         }
       ]

--- a/preload/images/storymenu/props/dad.xml
+++ b/preload/images/storymenu/props/dad.xml
@@ -2,16 +2,16 @@
 
 <TextureAtlas imagePath="dad.png" width="661" height="1143">
   <SubTexture name="idle0001" x="8" y="8" width="206" height="364" frameX="-0" frameY="-4" frameWidth="206" frameHeight="368" />
-  <SubTexture name="idle0003" x="8" y="388" width="205" height="363" frameX="-0" frameY="-5" frameWidth="206" frameHeight="368" />
-  <SubTexture name="idle0005" x="230" y="8" width="204" height="364" frameX="-1" frameY="-4" frameWidth="206" frameHeight="368" />
-  <SubTexture name="idle0007" x="8" y="767" width="202" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
-  <SubTexture name="idle0009" x="229" y="388" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
-  <SubTexture name="idle0011" x="450" y="8" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0002" x="8" y="8" width="206" height="364" frameX="-0" frameY="-4" frameWidth="206" frameHeight="368" />
+  <SubTexture name="idle0003" x="8" y="388" width="205" height="363" frameX="-0" frameY="-5" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0004" x="8" y="388" width="205" height="363" frameX="-0" frameY="-5" frameWidth="206" frameHeight="368" />
+  <SubTexture name="idle0005" x="230" y="8" width="204" height="364" frameX="-1" frameY="-4" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0006" x="230" y="8" width="204" height="364" frameX="-1" frameY="-4" frameWidth="206" frameHeight="368" />
+  <SubTexture name="idle0007" x="8" y="767" width="202" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0008" x="8" y="767" width="202" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
+  <SubTexture name="idle0009" x="229" y="388" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0010" x="229" y="388" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
+  <SubTexture name="idle0011" x="450" y="8" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0012" x="450" y="8" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0013" x="450" y="8" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />
   <SubTexture name="idle0014" x="450" y="8" width="203" height="368" frameX="-2" frameY="-0" frameWidth="206" frameHeight="368" />

--- a/preload/images/storymenu/props/darnell.xml
+++ b/preload/images/storymenu/props/darnell.xml
@@ -3,16 +3,16 @@
 <TextureAtlas imagePath="darnell.png" width="1821" height="217">
   <SubTexture name="idle0001" x="8" y="8" width="240" height="191" rotated="true" frameX="-0" frameY="-8" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0002" x="264" y="8" width="240" height="191" rotated="true" frameX="-0" frameY="-8" frameWidth="201" frameHeight="248" />
-  <SubTexture name="idle0009" x="520" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
-  <SubTexture name="idle0013" x="784" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
-  <SubTexture name="idle0007" x="1048" y="8" width="248" height="198" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
-  <SubTexture name="idle0005" x="1312" y="8" width="245" height="200" rotated="true" frameX="-1" frameY="-3" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0003" x="1573" y="8" width="240" height="201" rotated="true" frameX="-0" frameY="-8" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0004" x="1573" y="8" width="240" height="201" rotated="true" frameX="-0" frameY="-8" frameWidth="201" frameHeight="248" />
+  <SubTexture name="idle0005" x="1312" y="8" width="245" height="200" rotated="true" frameX="-1" frameY="-3" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0006" x="1312" y="8" width="245" height="200" rotated="true" frameX="-1" frameY="-3" frameWidth="201" frameHeight="248" />
+  <SubTexture name="idle0007" x="1048" y="8" width="248" height="198" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0008" x="1048" y="8" width="248" height="198" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
+  <SubTexture name="idle0009" x="520" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0010" x="520" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0011" x="520" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0012" x="520" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
+  <SubTexture name="idle0013" x="784" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
   <SubTexture name="idle0014" x="784" y="8" width="248" height="197" rotated="true" frameX="-1" frameY="-0" frameWidth="201" frameHeight="248" />
 </TextureAtlas>

--- a/preload/images/storymenu/props/gf.xml
+++ b/preload/images/storymenu/props/gf.xml
@@ -1,34 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TextureAtlas imagePath="gf.png" width="1774" height="1301">
-  <SubTexture name="idle0003" x="8" y="8" width="340" height="305" frameX="-0" frameY="-8" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0004" x="364" y="8" width="338" height="305" frameX="-1" frameY="-8" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0001" x="718" y="8" width="338" height="306" frameX="-1" frameY="-7" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0002" x="1072" y="8" width="340" height="306" frameX="-0" frameY="-7" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0003" x="8" y="8" width="340" height="305" frameX="-0" frameY="-8" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0004" x="364" y="8" width="338" height="305" frameX="-1" frameY="-8" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0005" x="1428" y="8" width="338" height="307" frameX="-1" frameY="-6" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0006" x="8" y="329" width="338" height="307" frameX="-1" frameY="-6" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0007" x="8" y="652" width="338" height="308" frameX="-1" frameY="-5" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0008" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0009" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0010" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0011" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0012" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0013" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0014" x="1424" y="980" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0015" x="1424" y="980" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0016" x="362" y="329" width="338" height="307" frameX="-1" frameY="-6" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0017" x="716" y="330" width="340" height="307" frameX="-0" frameY="-6" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0018" x="1072" y="330" width="340" height="307" frameX="-0" frameY="-6" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0019" x="1428" y="331" width="338" height="307" frameX="-1" frameY="-6" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0007" x="8" y="652" width="338" height="308" frameX="-1" frameY="-5" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0020" x="362" y="652" width="338" height="308" frameX="-1" frameY="-5" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0021" x="716" y="653" width="338" height="308" frameX="-1" frameY="-5" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0022" x="1070" y="653" width="338" height="308" frameX="-1" frameY="-5" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0026" x="1424" y="654" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0029" x="8" y="976" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0023" x="362" y="976" width="338" height="311" frameX="-1" frameY="-2" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0008" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0011" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0014" x="1424" y="980" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0009" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0010" x="716" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0012" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0013" x="1070" y="977" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
-  <SubTexture name="idle0015" x="1424" y="980" width="338" height="313" frameX="-1" frameY="-0" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0024" x="362" y="976" width="338" height="311" frameX="-1" frameY="-2" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0025" x="362" y="976" width="338" height="311" frameX="-1" frameY="-2" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0026" x="1424" y="654" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0027" x="1424" y="654" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0028" x="1424" y="654" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
+  <SubTexture name="idle0029" x="8" y="976" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
   <SubTexture name="idle0030" x="8" y="976" width="338" height="310" frameX="-1" frameY="-3" frameWidth="340" frameHeight="313" />
 </TextureAtlas>

--- a/preload/images/storymenu/props/mom.xml
+++ b/preload/images/storymenu/props/mom.xml
@@ -10,7 +10,7 @@
   <SubTexture name="idle0007" x="859" y="8" width="411" height="193" rotated="true" frameX="-0" frameY="-3" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0008" x="859" y="8" width="411" height="193" rotated="true" frameX="-0" frameY="-3" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0009" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle00010" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0010" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0011" x="8" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0012" x="8" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0013" x="438" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />

--- a/preload/images/storymenu/props/mom.xml
+++ b/preload/images/storymenu/props/mom.xml
@@ -2,17 +2,17 @@
 
 <TextureAtlas imagePath="mom.png" width="1707" height="419">
   <SubTexture name="idle0001" x="8" y="8" width="412" height="193" rotated="true" frameX="-2" frameY="-2" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0002" x="436" y="8" width="407" height="193" rotated="true" frameX="-2" frameY="-7" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0006" x="859" y="8" width="411" height="193" rotated="true" frameX="-0" frameY="-3" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0008" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0010" x="8" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0012" x="438" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0004" x="868" y="217" width="410" height="194" rotated="true" frameX="-0" frameY="-4" frameWidth="195" frameHeight="414" />
-  <SubTexture name="idle0014" x="8" y="8" width="412" height="193" rotated="true" frameX="-2" frameY="-2" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0002" x="8" y="8" width="412" height="193" rotated="true" frameX="-2" frameY="-2" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0003" x="436" y="8" width="407" height="193" rotated="true" frameX="-2" frameY="-7" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0004" x="436" y="8" width="407" height="193" rotated="true" frameX="-2" frameY="-7" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0005" x="868" y="217" width="410" height="194" rotated="true" frameX="-0" frameY="-4" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0006" x="868" y="217" width="410" height="194" rotated="true" frameX="-0" frameY="-4" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0007" x="859" y="8" width="411" height="193" rotated="true" frameX="-0" frameY="-3" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0008" x="859" y="8" width="411" height="193" rotated="true" frameX="-0" frameY="-3" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0009" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle00010" x="1286" y="8" width="413" height="193" rotated="true" frameX="-0" frameY="-1" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0011" x="8" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0012" x="8" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
   <SubTexture name="idle0013" x="438" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
+  <SubTexture name="idle0014" x="438" y="217" width="414" height="193" rotated="true" frameX="-0" frameY="-0" frameWidth="195" frameHeight="414" />
 </TextureAtlas>

--- a/preload/images/storymenu/props/nene.xml
+++ b/preload/images/storymenu/props/nene.xml
@@ -1,17 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TextureAtlas imagePath="nene.png" width="2015" height="2402">
-  <SubTexture name="idle0016" x="8" y="8" width="401" height="321" frameX="-1" frameY="-9" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0017" x="425" y="8" width="401" height="321" frameX="-1" frameY="-9" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0018" x="842" y="8" width="402" height="321" frameX="-0" frameY="-9" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0019" x="1260" y="8" width="402" height="321" frameX="-0" frameY="-9" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0001" x="1678" y="8" width="326" height="401" rotated="true" frameX="-1" frameY="-4" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0020" x="8" y="345" width="401" height="322" frameX="-1" frameY="-8" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0021" x="425" y="345" width="401" height="322" frameX="-1" frameY="-8" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0022" x="842" y="345" width="401" height="323" frameX="-1" frameY="-7" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0002" x="1259" y="345" width="402" height="326" frameX="-0" frameY="-4" frameWidth="402" frameHeight="330" />
-  <SubTexture name="idle0004" x="1677" y="425" width="327" height="401" rotated="true" frameX="-1" frameY="-3" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0003" x="8" y="683" width="402" height="327" frameX="-0" frameY="-3" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0004" x="1677" y="425" width="327" height="401" rotated="true" frameX="-1" frameY="-3" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0005" x="426" y="684" width="401" height="328" frameX="-1" frameY="-2" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0006" x="843" y="687" width="401" height="328" frameX="-1" frameY="-2" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0007" x="1260" y="687" width="401" height="328" frameX="-1" frameY="-2" frameWidth="402" frameHeight="330" />
@@ -23,6 +16,13 @@
   <SubTexture name="idle0013" x="1676" y="1259" width="330" height="401" rotated="true" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0014" x="8" y="1372" width="401" height="330" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0015" x="425" y="1374" width="401" height="330" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0016" x="8" y="8" width="401" height="321" frameX="-1" frameY="-9" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0017" x="425" y="8" width="401" height="321" frameX="-1" frameY="-9" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0018" x="842" y="8" width="402" height="321" frameX="-0" frameY="-9" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0019" x="1260" y="8" width="402" height="321" frameX="-0" frameY="-9" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0020" x="8" y="345" width="401" height="322" frameX="-1" frameY="-8" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0021" x="425" y="345" width="401" height="322" frameX="-1" frameY="-8" frameWidth="402" frameHeight="330" />
+  <SubTexture name="idle0022" x="842" y="345" width="401" height="323" frameX="-1" frameY="-7" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0023" x="842" y="1377" width="401" height="330" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0024" x="1259" y="1377" width="401" height="330" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />
   <SubTexture name="idle0025" x="8" y="1718" width="401" height="330" frameX="-1" frameY="-0" frameWidth="402" frameHeight="330" />

--- a/preload/images/storymenu/props/parents-xmas.xml
+++ b/preload/images/storymenu/props/parents-xmas.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TextureAtlas imagePath="parents-xmas.png" width="1769" height="786">
-  <SubTexture name="idle0003" x="8" y="8" width="427" height="370" frameX="-0" frameY="-11" frameWidth="431" frameHeight="381" />
-  <SubTexture name="idle0005" x="451" y="8" width="428" height="373" frameX="-2" frameY="-8" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0001" x="895" y="8" width="427" height="378" frameX="-2" frameY="-3" frameWidth="431" frameHeight="381" />
-  <SubTexture name="idle0007" x="1338" y="8" width="423" height="379" frameX="-8" frameY="-2" frameWidth="431" frameHeight="381" />
-  <SubTexture name="idle0009" x="8" y="394" width="422" height="380" frameX="-9" frameY="-1" frameWidth="431" frameHeight="381" />
-  <SubTexture name="idle0011" x="446" y="397" width="422" height="381" frameX="-9" frameY="-0" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0002" x="895" y="8" width="427" height="378" frameX="-2" frameY="-3" frameWidth="431" frameHeight="381" />
+  <SubTexture name="idle0003" x="8" y="8" width="427" height="370" frameX="-0" frameY="-11" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0004" x="8" y="8" width="427" height="370" frameX="-0" frameY="-11" frameWidth="431" frameHeight="381" />
+  <SubTexture name="idle0005" x="451" y="8" width="428" height="373" frameX="-2" frameY="-8" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0006" x="451" y="8" width="428" height="373" frameX="-2" frameY="-8" frameWidth="431" frameHeight="381" />
+  <SubTexture name="idle0007" x="1338" y="8" width="423" height="379" frameX="-8" frameY="-2" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0008" x="1338" y="8" width="423" height="379" frameX="-8" frameY="-2" frameWidth="431" frameHeight="381" />
+  <SubTexture name="idle0009" x="8" y="394" width="422" height="380" frameX="-9" frameY="-1" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0010" x="8" y="394" width="422" height="380" frameX="-9" frameY="-1" frameWidth="431" frameHeight="381" />
+  <SubTexture name="idle0011" x="446" y="397" width="422" height="381" frameX="-9" frameY="-0" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0012" x="446" y="397" width="422" height="381" frameX="-9" frameY="-0" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0013" x="446" y="397" width="422" height="381" frameX="-9" frameY="-0" frameWidth="431" frameHeight="381" />
   <SubTexture name="idle0014" x="446" y="397" width="422" height="381" frameX="-9" frameY="-0" frameWidth="431" frameHeight="381" />

--- a/preload/images/storymenu/props/pico.xml
+++ b/preload/images/storymenu/props/pico.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TextureAtlas imagePath="pico.png" width="475" height="1004">
-  <SubTexture name="idle0009" x="8" y="8" width="221" height="237" frameX="-5" frameY="-0" frameWidth="226" frameHeight="237" />
-  <SubTexture name="idle0007" x="8" y="261" width="222" height="236" frameX="-4" frameY="-1" frameWidth="226" frameHeight="237" />
-  <SubTexture name="idle0008" x="245" y="8" width="221" height="236" frameX="-5" frameY="-1" frameWidth="226" frameHeight="237" />
-  <SubTexture name="idle0003" x="8" y="513" width="221" height="234" frameX="-0" frameY="-3" frameWidth="226" frameHeight="237" />
-  <SubTexture name="idle0005" x="8" y="763" width="224" height="233" frameX="-2" frameY="-4" frameWidth="226" frameHeight="237" />
-  <SubTexture name="idle0006" x="245" y="513" width="222" height="233" frameX="-4" frameY="-4" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0001" x="246" y="260" width="217" height="230" frameX="-0" frameY="-7" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0002" x="246" y="260" width="217" height="230" frameX="-0" frameY="-7" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0003" x="8" y="513" width="221" height="234" frameX="-0" frameY="-3" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0004" x="8" y="513" width="221" height="234" frameX="-0" frameY="-3" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0005" x="8" y="763" width="224" height="233" frameX="-2" frameY="-4" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0006" x="245" y="513" width="222" height="233" frameX="-4" frameY="-4" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0007" x="8" y="261" width="222" height="236" frameX="-4" frameY="-1" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0008" x="245" y="8" width="221" height="236" frameX="-5" frameY="-1" frameWidth="226" frameHeight="237" />
+  <SubTexture name="idle0009" x="8" y="8" width="221" height="237" frameX="-5" frameY="-0" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0010" x="8" y="8" width="221" height="237" frameX="-5" frameY="-0" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0011" x="8" y="8" width="221" height="237" frameX="-5" frameY="-0" frameWidth="226" frameHeight="237" />
   <SubTexture name="idle0012" x="8" y="8" width="221" height="237" frameX="-5" frameY="-0" frameWidth="226" frameHeight="237" />

--- a/preload/images/storymenu/props/senpai.xml
+++ b/preload/images/storymenu/props/senpai.xml
@@ -2,14 +2,14 @@
 
 <TextureAtlas imagePath="senpai.png" width="1765" height="304">
   <SubTexture name="idle0001" x="8" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
-  <SubTexture name="idle0003" x="361" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
-  <SubTexture name="idle0005" x="714" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
-  <SubTexture name="idle0007" x="1067" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
-  <SubTexture name="idle0009" x="1420" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0002" x="8" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
+  <SubTexture name="idle0003" x="361" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0004" x="361" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
+  <SubTexture name="idle0005" x="714" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0006" x="714" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
+  <SubTexture name="idle0007" x="1067" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0008" x="1067" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
+  <SubTexture name="idle0009" x="1420" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0010" x="1420" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0011" x="1420" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />
   <SubTexture name="idle0012" x="1420" y="8" width="337" height="288" frameX="-0" frameY="-0" frameWidth="337" frameHeight="288" />

--- a/preload/images/storymenu/props/spooky.xml
+++ b/preload/images/storymenu/props/spooky.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <TextureAtlas imagePath="spooky.png" width="1584" height="250">
-  <SubTexture name="idle0007" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0005" x="260" y="8" width="230" height="171" rotated="true" frameX="-37" frameY="-29" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0003" x="506" y="8" width="257" height="181" rotated="true" frameX="-26" frameY="-4" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0001" x="779" y="8" width="261" height="182" rotated="true" frameX="-23" frameY="-0" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0011" x="1056" y="8" width="250" height="229" rotated="true" frameX="-3" frameY="-9" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0009" x="1322" y="8" width="254" height="234" rotated="true" frameX="-0" frameY="-7" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0002" x="779" y="8" width="261" height="182" rotated="true" frameX="-23" frameY="-0" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0003" x="506" y="8" width="257" height="181" rotated="true" frameX="-26" frameY="-4" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0004" x="506" y="8" width="257" height="181" rotated="true" frameX="-26" frameY="-4" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0005" x="260" y="8" width="230" height="171" rotated="true" frameX="-37" frameY="-29" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0006" x="260" y="8" width="230" height="171" rotated="true" frameX="-37" frameY="-29" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0007" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0008" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0009" x="1322" y="8" width="254" height="234" rotated="true" frameX="-0" frameY="-7" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0010" x="1322" y="8" width="254" height="234" rotated="true" frameX="-0" frameY="-7" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0011" x="1056" y="8" width="250" height="229" rotated="true" frameX="-3" frameY="-9" frameWidth="234" frameHeight="261" />
+  <SubTexture name="idle0012" x="1056" y="8" width="250" height="229" rotated="true" frameX="-3" frameY="-9" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0013" x="260" y="8" width="230" height="171" rotated="true" frameX="-37" frameY="-29" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0014" x="260" y="8" width="230" height="171" rotated="true" frameX="-37" frameY="-29" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0008" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0015" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
   <SubTexture name="idle0016" x="8" y="8" width="236" height="169" rotated="true" frameX="-37" frameY="-24" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0010" x="1322" y="8" width="254" height="234" rotated="true" frameX="-0" frameY="-7" frameWidth="234" frameHeight="261" />
-  <SubTexture name="idle0012" x="1056" y="8" width="250" height="229" rotated="true" frameX="-3" frameY="-9" frameWidth="234" frameHeight="261" />
 </TextureAtlas>

--- a/preload/images/storymenu/props/tankman.xml
+++ b/preload/images/storymenu/props/tankman.xml
@@ -2,14 +2,14 @@
 
 <TextureAtlas imagePath="tankman.png" width="1882" height="246">
   <SubTexture name="idle0001" x="8" y="8" width="292" height="228" rotated="true" frameX="-3" frameY="-10" frameWidth="231" frameHeight="302" />
-  <SubTexture name="idle0005" x="316" y="8" width="295" height="228" rotated="true" frameX="-1" frameY="-7" frameWidth="231" frameHeight="302" />
+  <SubTexture name="idle0002" x="8" y="8" width="292" height="228" rotated="true" frameX="-3" frameY="-10" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0003" x="627" y="8" width="293" height="229" rotated="true" frameX="-2" frameY="-9" frameWidth="231" frameHeight="302" />
+  <SubTexture name="idle0004" x="627" y="8" width="293" height="229" rotated="true" frameX="-2" frameY="-9" frameWidth="231" frameHeight="302" />
+  <SubTexture name="idle0005" x="316" y="8" width="295" height="228" rotated="true" frameX="-1" frameY="-7" frameWidth="231" frameHeight="302" />
+  <SubTexture name="idle0006" x="316" y="8" width="295" height="228" rotated="true" frameX="-1" frameY="-7" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0007" x="936" y="8" width="302" height="229" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0008" x="1254" y="8" width="302" height="230" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0009" x="1572" y="8" width="302" height="230" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />
-  <SubTexture name="idle0002" x="8" y="8" width="292" height="228" rotated="true" frameX="-3" frameY="-10" frameWidth="231" frameHeight="302" />
-  <SubTexture name="idle0004" x="627" y="8" width="293" height="229" rotated="true" frameX="-2" frameY="-9" frameWidth="231" frameHeight="302" />
-  <SubTexture name="idle0006" x="316" y="8" width="295" height="228" rotated="true" frameX="-1" frameY="-7" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0010" x="1572" y="8" width="302" height="230" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0011" x="1572" y="8" width="302" height="230" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />
   <SubTexture name="idle0012" x="1572" y="8" width="302" height="230" rotated="true" frameX="-0" frameY="-0" frameWidth="231" frameHeight="302" />


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
FunkinCrew/Funkin/issues/5766

<!-- Briefly describe the issue(s) fixed. -->
## Description
1. Improved BF `"confirm"` animation offsets in Story Mode (If you look closely at the original offsets, BF's animation moves slightly down).
2. Improved Pico `"confirm"` animation offsets in Story Mode (Similarly, if you look at the original offsets for Pico's animation, it also moves down and to the left).
3. Fixed Mom `"idle"` animation desync in the Story Mode menu.
- The index (I don't know if they are called indexes, I don't trust the translator, lol) of frame `0014` of the `"idle"` animation in `mom.xml` was actually `0001`, but for some reason it was used as the last frame, which is why the animation was out of sync.

Also, why the hell do the .xml files for several characters' props have such bad order in the animation indices? That's why mom.xml diff is so big. I sorted her animation indices (~I can do this for all the other characters if you ask me~ I did it beacuse I was bored)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
BF Story Mode offsets comparison.

https://github.com/user-attachments/assets/1daa71eb-8b76-43d9-98c8-a8296d543619


Pico Story Mode offsets comparison.

https://github.com/user-attachments/assets/40d9cacd-bf0d-4e3a-a010-df6c60e5a7c7


Mom Story Mode animation comparison.

https://github.com/user-attachments/assets/359e9298-af85-4a4a-9036-99444f4ab051

