### PR TITLE
`[feat/flixel-animate]` Nudge Freeplay Pico's y Position to be consistent with Freeplay BF

### DIFF
--- a/preload/data/players/pico.json
+++ b/preload/data/players/pico.json
@@ -39,37 +39,37 @@
       {
         "name": "intro",
         "prefix": "pico dj intro",
-        "offsets": [-54.5, -159]
+        "offsets": [-54.5, -156]
       },
       {
         "name": "idle",
         "prefix": "Pico DJ",
-        "offsets": [10, 270]
+        "offsets": [10, 273]
       },
       {
         "name": "idleEasterEgg",
         "prefix": "Pico DJ afk",
-        "offsets": [-119.5, 131.5]
+        "offsets": [-119.5, 134.5]
       },
       {
         "name": "confirm",
         "prefix": "Pico DJ confirm",
-        "offsets": [-54.5, 281]
+        "offsets": [-54.5, 284]
       },
       {
         "name": "fistPump",
         "prefix": "pico cheer",
-        "offsets": [-14.3, 58.5]
+        "offsets": [-14.3, 61.5]
       },
       {
         "name": "loss",
         "prefix": "Pico DJ loss",
-        "offsets": [-8, 221]
+        "offsets": [-8, 224]
       },
       {
         "name": "charSelect",
         "prefix": "Pico DJ to CS",
-        "offsets": [-62, -15]
+        "offsets": [-62, -12]
       }
     ]
   },


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
This? https://github.com/FunkinCrew/Funkin/pull/5852
(idk, I was working on both at the same time)

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None yet!

<!-- Briefly describe the issue(s) fixed. -->
## Description
Freeplay Pico's y Positioning didn't match Freeplay BF's, so I gave it a little nudge for all the animations to fix it

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/dcd4b401-0ad4-4fa5-b130-48330244b89d


