### PR TITLE
[BUGFIX] Fix Stress (Pico Mix) bricks moving when restarting

### DIFF
--- a/preload/scripts/stages/tankmanBattlefieldErect.hxc
+++ b/preload/scripts/stages/tankmanBattlefieldErect.hxc
@@ -128,5 +128,10 @@ class TankmanBattlefieldErectStage extends Stage
     {
       tankmanRim.useAltMask = false;
     }
+
+    if (getGirlfriend().characterId == 'otis-speaker')
+    {
+      getNamedProp('tankBricks').setPosition(445, 774);
+    }
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
FunkinCrew/Funkin#5875

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes FunkinCrew/Funkin#5595

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR along with the associated one fixes a bug where the bricks in Stress (Pico Mix) move upon restarting the song. This PR was made due to a script change that had to be done.