### PR TITLE
[BUGFIX] Fix A-Bot freezing when restarting the song

### DIFF
--- a/preload/scripts/characters/nene-christmas.hxc
+++ b/preload/scripts/characters/nene-christmas.hxc
@@ -294,13 +294,15 @@ class NeneChristmasCharacter extends SparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();

--- a/preload/scripts/characters/nene-dark.hxc
+++ b/preload/scripts/characters/nene-dark.hxc
@@ -374,13 +374,15 @@ class NeneDarkCharacter extends SparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();

--- a/preload/scripts/characters/nene-pixel.hxc
+++ b/preload/scripts/characters/nene-pixel.hxc
@@ -323,13 +323,15 @@ class NenePixelCharacter extends SparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();

--- a/preload/scripts/characters/nene-tankmen.hxc
+++ b/preload/scripts/characters/nene-tankmen.hxc
@@ -392,13 +392,15 @@ class NeneTankmenCharacter extends MultiSparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();

--- a/preload/scripts/characters/nene.hxc
+++ b/preload/scripts/characters/nene.hxc
@@ -388,13 +388,15 @@ class NeneCharacter extends MultiSparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();

--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -263,13 +263,15 @@ class OtisSpeakerCharacter extends SparrowCharacter
   {
     abotViz.snd = FlxG.sound.music;
     abotViz.initAnalyzer();
+    abotViz.alpha = 1;
   }
 
-  /*override function onSongRetry(event:ScriptEvent)
-    {
-      super.onSongRetry();
-      abotViz.dumpSound();
-  }*/
+  override function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry();
+    abotViz.alpha = 0;
+  }
+
   override function onSongEnd(event:ScriptEvent)
   {
     super.onSongEnd();


### PR DESCRIPTION
## Associated Funkin PR
N/A

## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/5885

## Description
A-Bot's visualizer assumes the song is as the song position 0 when restarting the song and that the song is playing, so it uses the frequencies of that timestamp. Upon messing with it I've realized that setting `abotViz` alpha to 0 after restarting seems to hide this error perfectly well. 
Setting visible to false wouldn't work here since it takes the visibility values from nene in `onUpdate`.

## Screenshots/Videos

https://github.com/user-attachments/assets/9c9cbc19-df60-409c-87fa-c49abff2b901
