### PR TITLE
[BUGFIX] Organize all of the Song Metadata Files, and add `songVariations` and `altInstrumentals` to all Song Metadata Files

### DIFF
--- a/preload/data/songs/2hot/2hot-metadata.json
+++ b/preload/data/songs/2hot/2hot-metadata.json
@@ -1,24 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "2hot",
   "artist": "Kawai Sprite",
   "charter": "Jenny Crowe + Spazkid + ninjamuffin99",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 182, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "phillyStreets",
-    "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "darnell"
-    },
-    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "pico-playable","girlfriend": "nene","opponent": "darnell",
+      "instrumental": "","playerVocals": ["pico"],"opponentVocals": ["darnell"], "altInstrumentals": []
+    },
+    "stage": "phillyStreets",
     "noteStyle": "funkin",
+    "ratings": { "easy": 3, "normal": 4, "hard": 5},
     "album": "volume3",
-    "stickerPack": "bonus-weekend1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": "bonus-weekend1"
   },
-  "songName": "2hot",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 182 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/blammed/blammed-metadata-erect.json
+++ b/preload/data/songs/blammed/blammed-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Blammed Erect",
   "artist": "Kawai Sprite",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 170, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "instrumental": "erect"
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 11, "nightmare": 12 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:a2b20fb) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 170, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:a2b20fb) PROTOTYPE"
 }

--- a/preload/data/songs/blammed/blammed-metadata-pico.json
+++ b/preload/data/songs/blammed/blammed-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Blammed (Pico Mix)",
   "artist": "Metaroom (feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "pico",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "pico",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
-    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
+    "ratings": { "easy": 3, "normal": 4, "hard": 5},
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/blammed/blammed-metadata.json
+++ b/preload/data/songs/blammed/blammed-metadata.json
@@ -1,25 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Blammed",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "phillyTrain",
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": ["pico"]
+    },
+    "stage": "phillyTrain",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3},
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Blammed",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 165 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/blazin/blazin-metadata.json
+++ b/preload/data/songs/blazin/blazin-metadata.json
@@ -3,24 +3,25 @@
   "songName": "Blazin'",
   "artist": "Kawai Sprite",
   "charter": "fabs + PhantomArcade",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-blazin",
-      "girlfriend": "nene",
-      "opponent": "darnell-blazin"
+      "player": "pico-blazin","girlfriend": "nene","opponent": "darnell-blazin",
+      "instrumental": "", "altInstrumentals": []
     },
     "stage": "phillyBlazin",
     "noteStyle": "funkin",
-    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
+    "ratings": { "easy": 3, "normal": 4, "hard": 5},
     "album": "volume3",
-    "stickerPack": "bonus-weekend1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": "bonus-weekend1"
   },
-  "generatedBy": "Chart Editor Import (FNF Legacy)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/bopeebo/bopeebo-metadata-erect.json
+++ b/preload/data/songs/bopeebo/bopeebo-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Bopeebo Erect",
   "artist": "Kawai Sprite (feat. Saruky)",
   "charter": "Jenny Crowe + fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 123, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "instrumental": "erect"
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 7, "nightmare": 8 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 123, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 PROTOTYPE"
 }

--- a/preload/data/songs/bopeebo/bopeebo-metadata-pico.json
+++ b/preload/data/songs/bopeebo/bopeebo-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Bopeebo (Pico Mix)",
   "artist": "ThatAndyGuy (feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "dad",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "dad",
+      "instrumental": "pico","playerVocals": ["pico"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
+    "ratings": { "easy": 1, "normal": 2, "hard": 3},
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/bopeebo/bopeebo-metadata.json
+++ b/preload/data/songs/bopeebo/bopeebo-metadata.json
@@ -4,26 +4,24 @@
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
   "timeFormat": "ms",
-  "offsets": {
-    "instrumental": 0
-  },
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
   "timeChanges": [{ "t": 0, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
-    "ratings": { "easy": 1, "normal": 1, "hard": 2 },
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": ["pico"]
     },
     "stage": "mainStage",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 1, "hard": 2},
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "EliteMasterEric (by hand)"
 }

--- a/preload/data/songs/cocoa/cocoa-metadata-erect.json
+++ b/preload/data/songs/cocoa/cocoa-metadata-erect.json
@@ -3,25 +3,25 @@
   "songName": "Cocoa Erect",
   "artist": "Saster",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 174, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-christmas",
-      "girlfriend": "gf-christmas",
-      "opponent": "parents-christmas",
-      "instrumental": "erect",
-      "altInstrumentals": []
+      "player": "bf-christmas","girlfriend": "gf-christmas","opponent": "parents-christmas",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["parents-christmas"], "altInstrumentals": []
     },
     "stage": "mallXmasErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 7, "nightmare": 8 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 174, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/cocoa/cocoa-metadata-pico.json
+++ b/preload/data/songs/cocoa/cocoa-metadata-pico.json
@@ -3,26 +3,25 @@
   "songName": "Cocoa (Pico Mix)",
   "artist": "Six Impala (feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-christmas",
-      "girlfriend": "nene-christmas",
-      "opponent": "parents-christmas",
-      "instrumental": "pico",
-      "opponentVocals": ["parents-christmas"],
-      "playerVocals": ["pico-christmas"]
+      "player": "pico-christmas","girlfriend": "nene-christmas","opponent": "parents-christmas",
+      "instrumental": "pico","playerVocals": ["pico-christmas"],"opponentVocals": ["parents-christmas"], "altInstrumentals": []
     },
     "stage": "mallXmasErect",
     "noteStyle": "funkin",
+    "ratings": { "easy": 2, "normal": 3, "hard": 4},
     "album": "expansion2",
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.6.0 (rewrite/master:4891e54) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.6.0 (rewrite/master:4891e54) PROTOTYPE"
 }

--- a/preload/data/songs/cocoa/cocoa-metadata.json
+++ b/preload/data/songs/cocoa/cocoa-metadata.json
@@ -1,25 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Cocoa",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
     "songVariations": ["erect", "pico"],
-    "stage": "mallXmas",
-    "characters": {
-      "player": "bf-christmas",
-      "girlfriend": "gf-christmas",
-      "opponent": "parents-christmas",
-      "altInstrumentals": ["pico"]
-    },
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf-christmas","girlfriend": "gf-christmas","opponent": "parents-christmas",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["parents-christmas"], "altInstrumentals": ["pico"]
+    },
+    "stage": "mallXmas",
     "noteStyle": "funkin",
-    "ratings": { "easy": 1, "normal": 2, "hard": 2 },
+    "ratings": { "easy": 1, "normal": 2, "hard": 2},
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Cocoa",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 100 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/dadbattle/dadbattle-metadata-erect.json
+++ b/preload/data/songs/dadbattle/dadbattle-metadata-erect.json
@@ -1,27 +1,27 @@
 {
   "version": "2.2.4",
   "songName": "DadBattle Erect",
-  "charter": "Jenny Crowe + fabs + Spazkid",
   "artist": "Kawai Sprite",
-  "offsets": { "vocals": { "bf": 0, "dad": -8 } },
+  "charter": "Jenny Crowe + fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0, "vocals": { "bf": 0, "dad": -8 } },
+  "timeChanges": [{ "t": 0, "bpm": 190, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "instrumental": "erect"
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 9, "nightmare": 10 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:1b4fc89) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 190, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:1b4fc89) PROTOTYPE"
 }

--- a/preload/data/songs/dadbattle/dadbattle-metadata-pico.json
+++ b/preload/data/songs/dadbattle/dadbattle-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "DadBattle (Pico Mix)",
   "artist": "TeraVex (ft. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "dad",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "dad",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/dadbattle/dadbattle-metadata.json
+++ b/preload/data/songs/dadbattle/dadbattle-metadata.json
@@ -4,22 +4,24 @@
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
   "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
   "timeChanges": [{ "t": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "altInstrumentals": ["pico"]
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": ["pico"]
     },
     "stage": "mainStage",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3},
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "EliteMasterEric (by hand)"
 }

--- a/preload/data/songs/darnell/darnell-metadata-bf.json
+++ b/preload/data/songs/darnell/darnell-metadata-bf.json
@@ -3,25 +3,25 @@
   "songName": "Darnell (BF Mix)",
   "artist": "Saruky",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "darnell",
-      "instrumental": "bf",
-      "altInstrumentals": []
+      "player": "bf","girlfriend": "gf","opponent": "darnell",
+      "instrumental": "bf","playerVocals": ["bf"],"opponentVocals": ["darnell"], "altInstrumentals": []
     },
     "stage": "phillyStreetsErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (runners-fixins-v2:b962c1a) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (runners-fixins-v2:b962c1a) PROTOTYPE"
 }

--- a/preload/data/songs/darnell/darnell-metadata-erect.json
+++ b/preload/data/songs/darnell/darnell-metadata-erect.json
@@ -3,31 +3,25 @@
   "songName": "Darnell Erect",
   "artist": "Kawai Sprite",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
   "playData": {
     "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "darnell",
-      "instrumental": "erect",
-      "altInstrumentals": [],
-      "opponentVocals": ["darnell"],
-      "playerVocals": ["pico"]
+      "player": "pico-playable","girlfriend": "nene","opponent": "darnell",
+      "instrumental": "erect","playerVocals": ["pico"],"opponentVocals": ["darnell"], "altInstrumentals": []
     },
     "stage": "phillyStreetsErect",
     "noteStyle": "funkin",
-    "album": "expansion2",
-    "stickerPack": "bonus-weekend1",
     "ratings": { "erect": 8, "nightmare": 9 },
-    "previewStart": 0,
-    "previewEnd": 0
+    "album": "expansion2",
+    "stickerPack": "bonus-weekend1"
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.3",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.3"
 }

--- a/preload/data/songs/darnell/darnell-metadata.json
+++ b/preload/data/songs/darnell/darnell-metadata.json
@@ -3,28 +3,25 @@
   "songName": "Darnell",
   "artist": "Kawai Sprite",
   "charter": "fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
     "songVariations": ["bf", "erect"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "album": "volume3",
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "darnell",
-      "instrumental": "",
-      "altInstrumentals": ["bf"]
+      "player": "pico-playable","girlfriend": "nene","opponent": "darnell",
+      "instrumental": "","playerVocals": ["pico"],"opponentVocals": ["darnell"], "altInstrumentals": ["bf"]
     },
     "stage": "phillyStreets",
     "noteStyle": "funkin",
-    "stickerPack": "bonus-weekend1",
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
+    "ratings": { "easy": 2, "normal": 3, "hard": 4},
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": "bonus-weekend1"
   },
-  "generatedBy": "Chart Editor Import (FNF Legacy)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 155, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/eggnog/eggnog-metadata-erect.json
+++ b/preload/data/songs/eggnog/eggnog-metadata-erect.json
@@ -3,32 +3,25 @@
   "songName": "Eggnog Erect",
   "artist": "Saruky",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "b": 0, "bpm": 140, "n": 4, "d": 4, "bt": [4, 4, 4, 4] },{"t": 122000,"b": 284.6667,"bpm": 80,"n": 4,"d": 4,"bt": [4, 4, 4, 4]}],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-christmas",
-      "girlfriend": "gf-christmas",
-      "opponent": "parents-christmas",
-      "instrumental": "erect"
+      "player": "bf-christmas","girlfriend": "gf-christmas","opponent": "parents-christmas",
+      "instrumental": "erect","playerVocals": ["bf-christmas"],"opponentVocals": ["parents-christmas"], "altInstrumentals": []
     },
     "stage": "mallXmasErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 6, "nightmare": 7 },
     "album": "expansion1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.2 (rewrite/master:2f96429:MODIFIED)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 140, "n": 4, "d": 4, "bt": [4, 4, 4, 4] },
-    {
-      "t": 122000,
-      "b": 284.6667,
-      "bpm": 80,
-      "n": 4,
-      "d": 4,
-      "bt": [4, 4, 4, 4]
-    }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.2 (rewrite/master:2f96429:MODIFIED)"
 }

--- a/preload/data/songs/eggnog/eggnog-metadata-pico.json
+++ b/preload/data/songs/eggnog/eggnog-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Eggnog (Pico Mix)",
   "artist": "Teravex (ft. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-christmas",
-      "girlfriend": "nene-christmas",
-      "opponent": "parents-christmas",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-christmas","girlfriend": "nene-christmas","opponent": "parents-christmas",
+      "instrumental": "pico","playerVocals": ["pico-christmas"],"opponentVocals": ["parents-christmas"], "altInstrumentals": []
     },
     "stage": "mallXmasErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (rewrite/master:7cd19a0) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (rewrite/master:7cd19a0) PROTOTYPE"
 }

--- a/preload/data/songs/eggnog/eggnog-metadata.json
+++ b/preload/data/songs/eggnog/eggnog-metadata.json
@@ -1,26 +1,28 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Eggnog",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "mallXmas",
-    "characters": {
-      "player": "bf-christmas",
-      "girlfriend": "gf-christmas",
-      "opponent": "parents-christmas",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf-christmas","girlfriend": "gf-christmas","opponent": "parents-christmas",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["parents-christmas"], "altInstrumentals": ["pico"]
+    },
+    "stage": "mallXmas",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Eggnog",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 150 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }
+

--- a/preload/data/songs/fresh/fresh-metadata-erect.json
+++ b/preload/data/songs/fresh/fresh-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Fresh Erect",
   "artist": "Kohta Takahashi (feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 125, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "difficulties": ["erect", "nightmare"],
+    "songVariations": [],
+        "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "instrumental": "erect"
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 6, "nightmare": 7 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 125, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 PROTOTYPE"
 }

--- a/preload/data/songs/fresh/fresh-metadata-pico.json
+++ b/preload/data/songs/fresh/fresh-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Fresh (Pico Mix)",
   "artist": "Xploshi (ft. Saster)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "dad",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "dad",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["dad"], "altInstrumentals": []
     },
     "stage": "mainStageErect",
     "noteStyle": "funkin",
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
+    "ratings": {"easy": 2, "normal": 3, "hard": 4 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/fresh/fresh-metadata.json
+++ b/preload/data/songs/fresh/fresh-metadata.json
@@ -1,23 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Fresh",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "album": "volume1",
-    "stage": "mainStage",
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "dad",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
-    "ratings": { "easy": 1, "normal": 1, "hard": 2 },
     "difficulties": ["easy", "normal", "hard"],
-    "noteStyle": "funkin"
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "dad",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["dad"], "altInstrumentals": ["pico"]
+    },
+    "stage": "mainStage",
+    "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 1, "hard": 2},
+    "album": "volume1",
+    "stickerPack": null
   },
-  "songName": "Fresh",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 120 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/guns/guns-metadata-pico.json
+++ b/preload/data/songs/guns/guns-metadata-pico.json
@@ -3,38 +3,25 @@
   "songName": "Guns (Pico Mix)",
   "artist": "tsuyunoshi (ft. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 185, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
-  "offsets": {
-    "instrumental": 0
-  },
   "playData": {
     "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene-tankmen",
-      "opponent": "tankman",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene-tankmen","opponent": "tankman",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["tankman"], "altInstrumentals": []
     },
     "stage": "tankmanBattlefieldErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 0
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    {
-      "t": 0,
-      "b": 0,
-      "bpm": 185,
-      "n": 4,
-      "d": 4,
-      "bt": [4, 4, 4, 4]
-    }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/guns/guns-metadata.json
+++ b/preload/data/songs/guns/guns-metadata.json
@@ -1,26 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Guns",
   "artist": "Kawai Sprite",
   "charter": "MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 185, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "tankmanBattlefield",
     "songVariations": ["pico"],
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf-tankmen",
-      "opponent": "tankman",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
-    },
-    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf","girlfriend": "gf-tankmen","opponent": "tankman",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["tankman"], "altInstrumentals": ["pico"]
+    },
+    "stage": "tankmanBattlefield",
     "noteStyle": "funkin",
+    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Guns",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 185 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/high/high-metadata-erect.json
+++ b/preload/data/songs/high/high-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "High Erect",
   "artist": "Kohta Takahashi (feat. Kawai Sprite)",
   "charter": "PhantomArcade + fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 125, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-car",
-      "girlfriend": "gf-car",
-      "opponent": "mom-car",
-      "instrumental": "erect"
+      "player": "bf-car","girlfriend": "gf-car","opponent": "mom-car", 
+      "instrumental": "erect","playerVocals": ["bf-car"],"opponentVocals": ["mom-car"], "altInstrumentals": []
     },
     "stage": "limoRideErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 8, "nightmare": 9 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:9c19d95) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 125, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:9c19d95) PROTOTYPE"
 }

--- a/preload/data/songs/high/high-metadata.json
+++ b/preload/data/songs/high/high-metadata.json
@@ -4,21 +4,24 @@
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
   "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
   "timeChanges": [{ "t": 0, "bpm": 125, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "songVariations": ["erect"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf-car",
-      "girlfriend": "gf-car",
-      "opponent": "mom-car"
+      "player": "bf-car","girlfriend": "gf-car","opponent": "mom-car",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["mom"], "altInstrumentals": ["erect"]
     },
     "stage": "limoRide",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "EliteMasterEric (by hand)"
 }

--- a/preload/data/songs/lit-up/lit-up-metadata-bf.json
+++ b/preload/data/songs/lit-up/lit-up-metadata-bf.json
@@ -3,30 +3,25 @@
   "songName": "Lit Up (BF Mix)",
   "artist": "Saruky",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 176, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
   "playData": {
     "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "darnell",
-      "instrumental": "bf",
-      "altInstrumentals": [],
-      "opponentVocals": ["darnell"],
-      "playerVocals": ["bf"]
+      "player": "bf","girlfriend": "gf","opponent": "darnell",
+      "instrumental": "bf","playerVocals": ["bf"],"opponentVocals": ["darnell"], "altInstrumentals": []
     },
     "stage": "phillyStreetsErect",
     "noteStyle": "funkin",
-    "album": "expansion2",
     "ratings": { "easy": 4, "normal": 5, "hard": 6 },
-    "previewStart": 0,
-    "previewEnd": 0
+    "album": "expansion2",
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.3",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 176, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.3"
 }

--- a/preload/data/songs/lit-up/lit-up-metadata.json
+++ b/preload/data/songs/lit-up/lit-up-metadata.json
@@ -3,25 +3,25 @@
   "songName": "Lit Up",
   "artist": "Kawai Sprite",
   "charter": "Jenny Crowe + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 176, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": ["bf"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "darnell"
+      "player": "pico-playable","girlfriend": "nene","opponent": "darnell",
+      "instrumental": "","playerVocals": ["pico"],"opponentVocals": ["darnell"], "altInstrumentals": []
     },
     "stage": "phillyStreets",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
-    "songVariations": ["bf"],
     "album": "volume3",
-    "stickerPack": "bonus-weekend1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": "bonus-weekend1"
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (polish/charting-music-bg:27a4ed4) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 176, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (polish/charting-music-bg:27a4ed4) PROTOTYPE"
 }

--- a/preload/data/songs/milf/milf-metadata.json
+++ b/preload/data/songs/milf/milf-metadata.json
@@ -3,23 +3,25 @@
   "songName": "M.I.L.F",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf-car",
-      "girlfriend": "gf-car",
-      "opponent": "mom-car"
+      "player": "bf-car","girlfriend": "gf-car","opponent": "mom-car",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["mom"], "altInstrumentals": []
     },
     "stage": "limoRide",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "EliteMasterEric (by hand)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 180, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "EliteMasterEric (by hand)"
 }

--- a/preload/data/songs/monster/monster-metadata.json
+++ b/preload/data/songs/monster/monster-metadata.json
@@ -3,32 +3,25 @@
   "songName": "Monster",
   "artist": "BassetFilms",
   "charter": "ChaoticGamerCG + MtH + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 95 },{ "t": 41770, "bpm": 95 },{ "t": 44180, "bpm": 105 },{ "t": 80710, "bpm": 105 },{ "t": 81860, "bpm": 110 },{ "t": 81861, "bpm": 95 },{ "t": 117230, "bpm": 132 },{ "t": 131770, "bpm": 132 },{ "t": 133310, "bpm": 107 },{ "t": 133311, "bpm": 132 },{ "t": 133770, "bpm": 120 },{ "t": 42975, "bpm": 100 },{ "t": 81285, "bpm": 107.5 },{ "t": 132540, "bpm": 119.5 }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
-    "characters": { "player": "bf", "girlfriend": "gf", "opponent": "monster" },
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "monster",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["monster"], "altInstrumentals": []
+    },
     "stage": "spookyMansion",
     "noteStyle": "funkin",
     "ratings": { "easy": 1, "normal": 2, "hard": 2 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Chart Editor Import (FNF Legacy)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "bpm": 95 },
-    { "t": 41770, "bpm": 95 },
-    { "t": 44180, "bpm": 105 },
-    { "t": 80710, "bpm": 105 },
-    { "t": 81860, "bpm": 110 },
-    { "t": 81861, "bpm": 95 },
-    { "t": 117230, "bpm": 132 },
-    { "t": 131770, "bpm": 132 },
-    { "t": 133310, "bpm": 107 },
-    { "t": 133311, "bpm": 132 },
-    { "t": 133770, "bpm": 120 },
-    { "t": 42975, "bpm": 100 },
-    { "t": 81285, "bpm": 107.5 },
-    { "t": 132540, "bpm": 119.5 }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/philly-nice/philly-nice-metadata-erect.json
+++ b/preload/data/songs/philly-nice/philly-nice-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Philly Nice Erect",
   "artist": "Kawai Sprite (feat. Saruky)",
   "charter": "Spazkid + fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 175, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "instrumental": "erect"
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 8, "nightmare": 9 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:fe660bd) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 175, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:fe660bd) PROTOTYPE"
 }

--- a/preload/data/songs/philly-nice/philly-nice-metadata-pico.json
+++ b/preload/data/songs/philly-nice/philly-nice-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Philly Nice (Pico Mix)",
   "artist": "tsuyunoshi (ft. Saruky)",
   "charter": "Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 175, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "pico",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "pico",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 175, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/philly-nice/philly-nice-metadata.json
+++ b/preload/data/songs/philly-nice/philly-nice-metadata.json
@@ -1,25 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Philly Nice",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 175, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "phillyTrain",
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": ["pico"]
+    },
+    "stage": "phillyTrain",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Philly Nice",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 175 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/pico/pico-metadata-erect.json
+++ b/preload/data/songs/pico/pico-metadata-erect.json
@@ -3,25 +3,25 @@
   "songName": "Pico Erect",
   "artist": "Kawai Sprite (feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 162, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "instrumental": "erect",
-      "altInstrumentals": []
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 9, "nightmare": 10 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:fa92ebe) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 162, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:fa92ebe) PROTOTYPE"
 }

--- a/preload/data/songs/pico/pico-metadata-pico.json
+++ b/preload/data/songs/pico/pico-metadata-pico.json
@@ -3,32 +3,25 @@
   "songName": "Pico (Pico Mix)",
   "artist": "Metaroom (ft. Saster)",
   "charter": "fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene",
-      "opponent": "pico",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene","opponent": "pico",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["pico"], "altInstrumentals": []
     },
     "stage": "phillyTrainErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "expansion2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    {
-      "t": 0,
-      "b": 0,
-      "bpm": 150,
-      "n": 4,
-      "d": 4,
-      "bt": [4, 4, 4, 4]
-    }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/pico/pico-metadata.json
+++ b/preload/data/songs/pico/pico-metadata.json
@@ -1,23 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Pico",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "album": "volume1",
-    "stage": "phillyTrain",
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "pico",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
-    "ratings": { "easy": 1, "normal": 2, "hard": 2 },
-    "noteStyle": "funkin"
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "pico",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["pico"], "altInstrumentals": ["pico"]
+    },
+    "stage": "phillyTrain",
+    "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 2},
+    "album": "volume1",
+    "stickerPack": null
   },
-  "songName": "Pico",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 150 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/roses/roses-metadata-erect.json
+++ b/preload/data/songs/roses/roses-metadata-erect.json
@@ -3,25 +3,25 @@
   "songName": "Roses Erect",
   "charter": "Jenny Crowe + fabs + Spazkid",
   "artist": "Kawai Sprite",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 128, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "senpai-angry",
-      "instrumental": "erect"
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "senpai-angry",
+      "instrumental": "erect","playerVocals": ["bf-pixel"],"opponentVocals": ["senpai-angry"], "altInstrumentals": []
     },
     "stage": "schoolErect",
     "noteStyle": "pixel",
     "ratings": { "erect": 8, "nightmare": 9 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:7562143) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 128, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:7562143) PROTOTYPE"
 }

--- a/preload/data/songs/roses/roses-metadata-pico.json
+++ b/preload/data/songs/roses/roses-metadata-pico.json
@@ -3,28 +3,25 @@
   "songName": "Roses (Pico Mix)",
   "artist": "Xploshi (ft. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
   "playData": {
     "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-pixel",
-      "girlfriend": "nene-pixel",
-      "opponent": "senpai-angry",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-pixel","girlfriend": "nene-pixel","opponent": "senpai-angry",
+      "instrumental": "pico","playerVocals": ["pico-pixel"],"opponentVocals": ["senpai-angry"], "altInstrumentals": []
     },
     "stage": "schoolPico",
     "noteStyle": "pixel",
-    "album": "expansion2",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
-    "previewStart": 0,
-    "previewEnd": 15000
+    "album": "expansion2",
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.6.0 (rewrite/master:4891e54) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.6.0 (rewrite/master:4891e54) PROTOTYPE"
 }

--- a/preload/data/songs/roses/roses-metadata.json
+++ b/preload/data/songs/roses/roses-metadata.json
@@ -1,38 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Roses",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH + Spazkid",
-  "offsets": {
-    "instrumental": 0.0,
-    "altInstrumentals": {
-      "pico": -4000.0
-    },
-    "altVocals": {
-      "pico": {
-        "senpai-angry": 4000.0,
-        "bf-pixel": 4000.0
-      }
-    }
-  },
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0, "altInstrumentals": {"pico": -4000.0},"altVocals": {"pico": {"senpai-angry": 4000.0,"bf-pixel": 4000.0}}},
+  "timeChanges": [{ "t": -1, "bpm": 120, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "school",
-    "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "senpai-angry",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
-    },
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "senpai-angry",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["senpai"], "altInstrumentals": ["pico"]
+    },
+    "stage": "school",
     "noteStyle": "pixel",
+    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Roses",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 120 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/satin-panties/satin-panties-metadata-erect.json
+++ b/preload/data/songs/satin-panties/satin-panties-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Satin Panties Erect",
   "artist": "Kawai Sprite",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 135, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-car",
-      "girlfriend": "gf-car",
-      "opponent": "mom-car",
-      "instrumental": "erect"
+      "player": "bf-car","girlfriend": "gf-car","opponent": "mom-car",
+      "instrumental": "erect","playerVocals": ["bf-car"],"opponentVocals": ["mom-car"], "altInstrumentals": []
     },
     "stage": "limoRideErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 11, "nightmare": 12 },
     "album": "expansion1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:51a44d4) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 135, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:51a44d4) PROTOTYPE"
 }

--- a/preload/data/songs/satin-panties/satin-panties-metadata.json
+++ b/preload/data/songs/satin-panties/satin-panties-metadata.json
@@ -4,21 +4,24 @@
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH + Spazkid",
   "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
   "timeChanges": [{ "t": 0, "bpm": 110, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": ["erect"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf-car",
-      "girlfriend": "gf-car",
-      "opponent": "mom-car"
+      "player": "bf-car","girlfriend": "gf-car","opponent": "mom-car",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["mom"], "altInstrumentals": []
     },
-    "songVariations": ["erect"],
     "stage": "limoRide",
     "noteStyle": "funkin",
     "ratings": { "easy": 1, "normal": 2, "hard": 2 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "EliteMasterEric (by hand)"
 }

--- a/preload/data/songs/senpai/senpai-metadata-erect.json
+++ b/preload/data/songs/senpai/senpai-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Senpai Erect",
   "artist": "Kawai Sprite",
   "charter": "Jenny Crowe + fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 158, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "senpai",
-      "instrumental": "erect"
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "senpai",
+      "instrumental": "erect","playerVocals": ["bf-pixel"],"opponentVocals": ["senpai"], "altInstrumentals": []
     },
     "stage": "schoolErect",
     "noteStyle": "pixel",
     "ratings": { "erect": 6, "nightmare": 7 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (polish/charting-music-bg:27a4ed4) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 158, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (polish/charting-music-bg:27a4ed4) PROTOTYPE"
 }

--- a/preload/data/songs/senpai/senpai-metadata-pico.json
+++ b/preload/data/songs/senpai/senpai-metadata-pico.json
@@ -3,31 +3,25 @@
   "songName": "Senpai (Pico Mix)",
   "artist": "Tee Lopes (Feat. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 144, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
-  "offsets": {
-    "instrumental": 0
-  },
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-pixel",
-      "girlfriend": "nene-pixel",
-      "opponent": "senpai",
-      "instrumental": "pico",
-      "opponentVocals": ["senpai"],
-      "playerVocals": ["pico"]
+      "player": "pico-pixel","girlfriend": "nene-pixel","opponent": "senpai",
+      "instrumental": "pico","playerVocals": ["pico"],"opponentVocals": ["senpai"], "altInstrumentals": []
     },
     "stage": "schoolPico",
     "noteStyle": "pixel",
-    "album": "expansion2",
     "ratings": { "easy": 1, "normal": 2, "hard": 3 },
-    "previewStart": 0,
-    "previewEnd": 15000
+    "album": "expansion2",
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.3",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 144, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.3"
 }

--- a/preload/data/songs/senpai/senpai-metadata.json
+++ b/preload/data/songs/senpai/senpai-metadata.json
@@ -1,26 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Senpai",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 144, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "school",
-    "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "senpai",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
-    },
-    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "senpai",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["senpai"], "altInstrumentals": ["pico"]
+    },
+    "stage": "school",
     "noteStyle": "pixel",
+    "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Senpai",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 144 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/south/south-metadata-erect.json
+++ b/preload/data/songs/south/south-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "South Erect",
   "artist": "Kawai Sprite (feat. Saruky)",
   "charter": "Spazkid + fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 177, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-dark",
-      "girlfriend": "gf-dark",
-      "opponent": "spooky-dark",
-      "instrumental": "erect"
+      "player": "bf-dark","girlfriend": "gf-dark","opponent": "spooky-dark",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["spooky"], "altInstrumentals": []
     },
     "stage": "spookyMansionErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 8, "nightmare": 9 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:008fc3c) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 177, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:008fc3c) PROTOTYPE"
 }

--- a/preload/data/songs/south/south-metadata-pico.json
+++ b/preload/data/songs/south/south-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "South (Pico Mix)",
   "artist": "Six Impala (feat. Saster)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-dark",
-      "girlfriend": "nene-dark",
-      "opponent": "spooky-dark",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-dark","girlfriend": "nene-dark","opponent": "spooky-dark",
+      "instrumental": "pico","playerVocals": ["pico-playable"],"opponentVocals": ["spooky"], "altInstrumentals": []
     },
     "stage": "spookyMansionErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/south/south-metadata.json
+++ b/preload/data/songs/south/south-metadata.json
@@ -1,25 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "South",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 165, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "spookyMansion",
-    "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "spooky",
-      "altInstrumentals": ["pico"]
-    },
     "songVariations": ["erect", "pico"],
-    "ratings": { "easy": 1, "normal": 2, "hard": 2 },
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf","girlfriend": "gf","opponent": "spooky",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["spooky"], "altInstrumentals": ["pico"]
+    },
+    "stage": "spookyMansion",
     "noteStyle": "funkin",
+    "ratings": { "easy": 1, "normal": 2, "hard": 2 },
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "South",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 165 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/spookeez/spookeez-metadata-erect.json
+++ b/preload/data/songs/spookeez/spookeez-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Spookeez Erect",
   "artist": "Kawai Sprite (feat. Saruky)",
   "charter": "Spazkid + fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 166, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-dark",
-      "girlfriend": "gf-dark",
-      "opponent": "spooky-dark",
-      "instrumental": "erect"
+      "player": "bf-dark","girlfriend": "gf-dark","opponent": "spooky-dark",
+      "instrumental": "erect","playerVocals": ["bf-dark"],"opponentVocals": ["spooky-dark"], "altInstrumentals": []
     },
     "stage": "spookyMansionErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 11, "nightmare": 12 },
-    "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "album": "volume1",
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:f2e682d) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 166, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:bc783a2) PROTOTYPE"
 }

--- a/preload/data/songs/spookeez/spookeez-metadata-pico.json
+++ b/preload/data/songs/spookeez/spookeez-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Spookeez (Pico Mix)",
   "artist": "Six Impala (feat. Saster)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-dark",
-      "girlfriend": "nene-dark",
-      "opponent": "spooky-dark",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-dark","girlfriend": "nene-dark","opponent": "spooky-dark",
+      "instrumental": "pico","playerVocals": ["pico"],"opponentVocals": ["spooky"], "altInstrumentals": []
     },
     "stage": "spookyMansionErect",
     "noteStyle": "funkin",
     "ratings": { "easy": 1, "normal": 2, "hard": 3 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.4.1 (feature/playable-pico-mode:9b3a748) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.4.1 (feature/playable-pico-mode:9b3a748) PROTOTYPE"
 }

--- a/preload/data/songs/spookeez/spookeez-metadata.json
+++ b/preload/data/songs/spookeez/spookeez-metadata.json
@@ -3,26 +3,25 @@
   "songName": "Spookeez",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
     "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf",
-      "opponent": "spooky",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
+      "player": "bf","girlfriend": "gf","opponent": "spooky",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["spooky"], "altInstrumentals": ["pico"]
     },
     "stage": "spookyMansion",
     "noteStyle": "funkin",
-    "ratings": { "easy": 1, "normal": 1, "hard": 2 },
+    "ratings": { "easy": 1, "normal": 1, "hard": 2},
     "album": "volume1",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:bc783a2) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 150, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:bc783a2) PROTOTYPE"
 }

--- a/preload/data/songs/stress/stress-metadata-pico.json
+++ b/preload/data/songs/stress/stress-metadata-pico.json
@@ -3,30 +3,25 @@
   "songName": "Stress (Pico Mix)",
   "artist": "Saruky",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
   "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 178, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
   "looped": false,
   "playData": {
     "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-holding-nene",
-      "girlfriend": "otis-speaker",
-      "opponent": "tankman-bloody",
-      "instrumental": "pico",
-      "altInstrumentals": [],
-      "opponentVocals": ["tankman"],
-      "playerVocals": ["pico"]
+      "player": "pico-holding-nene","girlfriend": "otis-speaker","opponent": "tankman-bloody",
+      "instrumental": "pico","playerVocals": ["pico"],"opponentVocals": ["tankman"], "altInstrumentals": []
     },
     "stage": "tankmanBattlefieldErect",
     "noteStyle": "funkin",
-    "album": "expansion2",
     "ratings": { "easy": 4, "normal": 5, "hard": 6 },
-    "previewStart": 0,
-    "previewEnd": 15000
+    "album": "expansion2",
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.3",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 178, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.3"
 }

--- a/preload/data/songs/stress/stress-metadata.json
+++ b/preload/data/songs/stress/stress-metadata.json
@@ -3,26 +3,25 @@
   "songName": "Stress",
   "artist": "Kawai Sprite",
   "charter": "MtH + Spazkid + Hundrec",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 178, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": ["pico"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf-holding-gf",
-      "girlfriend": "pico-speaker",
-      "opponent": "tankman",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
+      "player": "bf-holding-gf","girlfriend": "pico-speaker","opponent": "tankman",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["tankman"], "altInstrumentals": ["pico"]
     },
     "stage": "tankmanBattlefield",
-    "songVariations": ["pico"],
     "noteStyle": "funkin",
-    "ratings": { "easy": 3, "normal": 4, "hard": 5 },
+    "ratings": { "easy": 3, "normal": 4, "hard": 6},
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.3 (freeplay-optimize:a72f357) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 178, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (freeplay-optimize:a72f357) PROTOTYPE"
 }

--- a/preload/data/songs/thorns/thorns-metadata-erect.json
+++ b/preload/data/songs/thorns/thorns-metadata-erect.json
@@ -3,24 +3,25 @@
   "songName": "Thorns Erect",
   "artist": "Kawai Sprite (feat. Saster)",
   "charter": "Jenny Crowe + fabs",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 190, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "spirit",
-      "instrumental": "erect"
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "spirit",
+      "instrumental": "erect","playerVocals": ["bf-pixel"],"opponentVocals": ["spirit"], "altInstrumentals": []
     },
     "stage": "schoolEvilErect",
     "noteStyle": "pixel",
     "ratings": { "erect": 9, "nightmare": 10 },
     "album": "volume3",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:2ff43f5) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 190, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.0 (rewrite/master:2ff43f5) PROTOTYPE"
 }

--- a/preload/data/songs/thorns/thorns-metadata.json
+++ b/preload/data/songs/thorns/thorns-metadata.json
@@ -1,26 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Thorns",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 190, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "stage": "schoolEvil",
-    "characters": {
-      "player": "bf-pixel",
-      "girlfriend": "gf-pixel",
-      "opponent": "spirit",
-      "instrumental": "",
-      "altInstrumentals": []
-    },
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "songVariations": ["erect"],
     "difficulties": ["easy", "normal", "hard"],
+    "characters": {
+      "player": "bf-pixel","girlfriend": "gf-pixel","opponent": "spirit",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["spirit"], "altInstrumentals": []
+    },
+    "stage": "schoolEvil",
     "noteStyle": "pixel",
+    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "songName": "Thorns",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 190 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/tutorial/tutorial-metadata.json
+++ b/preload/data/songs/tutorial/tutorial-metadata.json
@@ -1,20 +1,27 @@
 {
   "version": "2.2.4",
-  "timeFormat": "ms",
+  "songName": "Tutorial",
   "artist": "Kawai Sprite",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": -1, "bpm": 100, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
-    "ratings": { "easy": 0, "normal": 0, "hard": 1 },
-    "stage": "mainStage",
-    "characters": { "player": "bf", "opponent": "gf" },
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
+    "characters": { 
+      "player": "bf", "opponent": "gf",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["gf"], "altInstrumentals": []
+    },
+    "stage": "mainStage",
     "noteStyle": "funkin",
+    "ratings": { "easy": 0, "normal": 0, "hard": 1},
     "album": "volume1",
-    "stickerPack": "bonus-tutorial",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": "bonus-tutorial"
   },
-  "songName": "Tutorial",
-  "timeChanges": [{ "d": 4, "n": 4, "t": -1, "bt": [4, 4, 4, 4], "bpm": 100 }],
+  "previewStart": 0,
+  "previewEnd": 15000,
   "generatedBy": "Chart Editor Import (FNF Legacy)"
 }

--- a/preload/data/songs/ugh/ugh-metadata-erect.json
+++ b/preload/data/songs/ugh/ugh-metadata-erect.json
@@ -3,25 +3,25 @@
   "songName": "Ugh Erect",
   "artist": "Kawai Sprite",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 170, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["erect", "nightmare"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf-tankmen",
-      "opponent": "tankman",
-      "instrumental": "erect",
-      "altInstrumentals": []
+      "player": "bf","girlfriend": "gf-tankmen","opponent": "tankman",
+      "instrumental": "erect","playerVocals": ["bf"],"opponentVocals": ["tankman"], "altInstrumentals": []
     },
     "stage": "tankmanBattlefieldErect",
     "noteStyle": "funkin",
     "ratings": { "erect": 8, "nightmare": 9 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 170, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.5.0 (develop:96c151c:MODIFIED) PROTOTYPE"
 }

--- a/preload/data/songs/ugh/ugh-metadata-pico.json
+++ b/preload/data/songs/ugh/ugh-metadata-pico.json
@@ -3,25 +3,25 @@
   "songName": "Ugh (Pico Mix)",
   "artist": "tsuyunoshi (ft. Saruky)",
   "charter": "fabs + Spazkid",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 160, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "pico-playable",
-      "girlfriend": "nene-tankmen",
-      "opponent": "tankman",
-      "instrumental": "pico",
-      "altInstrumentals": []
+      "player": "pico-playable","girlfriend": "nene-tankmen","opponent": "tankman",
+      "instrumental": "pico","playerVocals": ["pico"],"opponentVocals": ["tankman"], "altInstrumentals": []
     },
     "stage": "tankmanBattlefieldErect",
     "noteStyle": "funkin",
-    "ratings": { "easy": 2, "normal": 3, "hard": 4 },
+    "ratings": {"easy": 2, "normal": 3, "hard": 4 },
     "album": "volume4",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.4.1 (rewrite/master:47b7aa7) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 160, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.4.1 (rewrite/master:47b7aa7) PROTOTYPE"
 }

--- a/preload/data/songs/ugh/ugh-metadata.json
+++ b/preload/data/songs/ugh/ugh-metadata.json
@@ -3,26 +3,25 @@
   "songName": "Ugh",
   "artist": "Kawai Sprite",
   "charter": "MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 160, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": ["erect", "pico"],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf",
-      "girlfriend": "gf-tankmen",
-      "opponent": "tankman",
-      "instrumental": "",
-      "altInstrumentals": ["pico"]
+      "player": "bf","girlfriend": "gf-tankmen","opponent": "tankman",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["tankman"], "altInstrumentals": ["pico"]
     },
-    "songVariations": ["erect", "pico"],
     "stage": "tankmanBattlefield",
     "noteStyle": "funkin",
     "ratings": { "easy": 2, "normal": 3, "hard": 4 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:6334d16) PROTOTYPE",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 160, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Friday Night Funkin' - v0.3.3 (rewrite/master:6334d16) PROTOTYPE"
 }

--- a/preload/data/songs/winter-horrorland/winter-horrorland-metadata.json
+++ b/preload/data/songs/winter-horrorland/winter-horrorland-metadata.json
@@ -3,23 +3,25 @@
   "songName": "Winter Horrorland",
   "artist": "Bassetfilms",
   "charter": "ninjamuffin99 + MtH",
+  "timeFormat": "ms",
+  "divisions": 96,
+  "offsets": {"instrumental": 0},
+  "timeChanges": [{ "t": 0, "bpm": 159, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }],
+  "looped": false,
   "playData": {
+    "songVariations": [],
     "difficulties": ["easy", "normal", "hard"],
     "characters": {
-      "player": "bf-christmas",
-      "girlfriend": "gf-christmas",
-      "opponent": "monster-christmas"
+      "player": "bf-christmas","girlfriend": "gf-christmas","opponent": "monster-christmas",
+      "instrumental": "","playerVocals": ["bf"],"opponentVocals": ["monster"], "altInstrumentals": []
     },
     "stage": "mallEvil",
     "noteStyle": "funkin",
     "ratings": { "easy": 1, "normal": 2, "hard": 2 },
     "album": "volume2",
-    "previewStart": 0,
-    "previewEnd": 15000
+    "stickerPack": null
   },
-  "generatedBy": "Chart Editor Import (FNF Legacy)",
-  "timeFormat": "ms",
-  "timeChanges": [
-    { "t": 0, "b": 0, "bpm": 159, "n": 4, "d": 4, "bt": [4, 4, 4, 4] }
-  ]
+  "previewStart": 0,
+  "previewEnd": 15000,
+  "generatedBy": "Chart Editor Import (FNF Legacy)"
 }


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/4581

<!-- Briefly describe the issue(s) fixed. -->
## Description
This merge adds fields for songVariations and altInstrumentals in song metadata files for those that are missing it. It does not effect any gameplay or visuals at all in the game but allows for Json merging for these songs, which makes making playable character mods a whole lot easier. Here is a list of what was added: 
2hot: alt and var
blazin: alt and var
cocoaPico: alt
high: alt
high erect: alt
lit-up: alt
milf: alt and var
monster: alt and var
satin: alt
senpaiPico: alt
thornsErect: alt
tutorial: alt and var
winter: alt and var
This also organizes all of the song metadata files so they are all nicely organized and sorted the same, making it easier for developers and modders