### PR TITLE
[BUGFIX] Move Chart Editor menu bar based on debug display

### DIFF
--- a/exclude/data/ui/chart-editor/components/menubar.xml
+++ b/exclude/data/ui/chart-editor/components/menubar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menubar id="menubar" width="100%" paddingLeft="172">
+<menubar id="menubar" width="100%" paddingLeft="245">
   <style>
     .menu {
     // The width of the individual menu items


### PR DESCRIPTION
## Description
Move menubar a little for new debugDisplay

## Screenshots/Videos
<img width="683" height="131" alt="image" src="https://github.com/user-attachments/assets/216cba0b-84b7-4295-92f0-022e3c14aa91" />
