### PR TITLE
[ENHANCEMENT] Change Animation Editor save shortcuts (funkin.assets)

### DIFF
--- a/preload/data/ui/animation-editor/offset-editor-view.xml
+++ b/preload/data/ui/animation-editor/offset-editor-view.xml
@@ -38,8 +38,8 @@
                 <label text="ARROWS: Nudge Offsets by 5" />
                 <label text="SHIFT+ARROWS: Nudge Offsets by 10" />
                 <label text="CTRL+ARROWS: Nudge Offsets by 1" />
-                <label text="ESC: Save Character Data to File" />
-                <label text="CTRL+ESC: Save Offsets to File" />
+                <label text="CTRL+S: Save Character Data to File" />
+                <label text="CTRL+SHIFT+S: Save Offsets to File" />
             </vbox>
         </scroll-view>
     </vbox>


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
FunkinCrew/Funkin#5974
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes FunkinCrew/Funkin#5931
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR changes the labels for the saving shortcuts in the Animation Editor to the new ones. See PR in the main repo for the reasoning for the new shortcuts.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
The new shortcut labels displayed in the dialog:
<img width="384" height="517" alt="Screenshot 2025-09-10 132013" src="https://github.com/user-attachments/assets/40f83a42-115b-4b54-a202-077bb202dc24" />