### PR TITLE
[BUGFIX] Fix pico-speaker not shooting after restarting in Stress

### DIFF
--- a/preload/scripts/songs/stress.hxc
+++ b/preload/scripts/songs/stress.hxc
@@ -91,7 +91,27 @@ class StressSong extends Song
 
     VideoCutscene.play(Paths.videos(videoPath));
   }
+  
+  /**
+   * Don't replay the cutscene between restarts.
+   */
+  function onSongRetry(event:ScriptEvent)
+  {
+    super.onSongRetry(event);
 
+    hasPlayedCutscene = true;
+
+    // resets the tankmen!
+    if (tankmanGroup != null)
+    {
+      tankmanGroup.scriptCall('reset');
+    }
+    if (PlayState.instance.currentStage.getGirlfriend() != null)
+    {
+      PlayState.instance.currentStage.getGirlfriend().scriptCall('reset');
+      trace('reset pico!');
+    }
+  }
   function kill():Void
   {
     cleanupTankmanGroup();


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
https://github.com/FunkinCrew/Funkin/issues/5960

<!-- Briefly describe the issue(s) fixed. -->
pico stops shooting after restarting the song or dying and then restarting the song in stress, this was a simple mistake by one of the devs when seperating the stress-default and stress-pico scripted song script files and they removed a piece of code that restarts the girlfriend character after a reset

note: this is my semi first pr please go easy on me 
