### PR TITLE
[BUGFIX] Check if Eggnog Erect cutscene was already skipped before attempting to skip it again

### DIFF
--- a/preload/scripts/songs/eggnog-erect.hxc
+++ b/preload/scripts/songs/eggnog-erect.hxc
@@ -185,9 +185,9 @@ class EggnogErectSong extends Song
 
     if (PlayState.instance.isInCutscene)
     {
-      if ((PlayState.instance.controls.CUTSCENE_ADVANCE || isMobilePauseButtonPressed) && cutsceneSkipped == false)
+      if ((PlayState.instance.controls.CUTSCENE_ADVANCE || isMobilePauseButtonPressed) && !cutsceneSkipped)
       {
-        if (canSkipCutscene == false)
+        if (!canSkipCutscene)
         {
           trace('cant skip yet!');
           FlxTween.tween(skipText, {alpha: 1}, 0.5, {ease: FlxEase.quadOut});
@@ -199,7 +199,7 @@ class EggnogErectSong extends Song
       }
     }
 
-    if ((PlayState.instance.controls.CUTSCENE_ADVANCE || isMobilePauseButtonPressed) && canSkipCutscene)
+    if ((PlayState.instance.controls.CUTSCENE_ADVANCE || isMobilePauseButtonPressed) && canSkipCutscene && !cutsceneSkipped)
     {
       PlayState.instance.camCutscene.fade(0xFF000000, 0.5, false, null, true);
       FlxTween.tween(skipText, {alpha: 0}, 0.5, {ease: FlxEase.quadOut});


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes FunkinCrew/Funkin#6043
<!-- Briefly describe the issue(s) fixed. -->
## Description
When pressing the key to skip the cutscene at the end of Eggnog Erect, the game doesn't check if you already skipped the cutscene. This causes the `endSong` function to get called multiple times if you mash the skip key, resulting in bugs.

This PR fixes the issue by adding a check to see if the cutscene was already skipped before attempting to skip it.
(I also simplified two other boolean expressions in this script)
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

I'm mashing the skip key and there are no bugs:

https://github.com/user-attachments/assets/9094837f-174b-4108-b629-2d97f78fca14