### PR TITLE
[BUGFIX] Add GF's 200 Combo Animation

### DIFF
--- a/preload/data/characters/gf-christmas.json
+++ b/preload/data/characters/gf-christmas.json
@@ -30,6 +30,11 @@
       "offsets": [0, -15]
     },
     {
+      "name": "combo200",
+      "prefix": "GF Cheer",
+      "offsets": [0, 0]
+    },
+    {
       "name": "drop70",
       "prefix": "gf sad",
       "animType": "symbol",

--- a/preload/data/characters/gf-dark.json
+++ b/preload/data/characters/gf-dark.json
@@ -27,6 +27,11 @@
       "prefix": "Cheer"
     },
     {
+      "name": "combo200",
+      "prefix": "GF Cheer",
+      "offsets": [0, 0]
+    },
+    {
       "name": "drop70",
       "prefix": "Crying",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]

--- a/preload/data/characters/gf.json
+++ b/preload/data/characters/gf.json
@@ -44,6 +44,11 @@
       "prefix": "Cheer"
     },
     {
+      "name": "combo200",
+      "prefix": "GF Cheer",
+      "offsets": [0, 0]
+    },
+    {
       "name": "drop70",
       "prefix": "Crying",
       "frameIndices": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes FunkinCrew/Funkin#6013

<!-- Briefly describe the issue(s) fixed. -->
## Description
For some reason, Girlfriend doesn't have a 200 combo animation, so this pr adds that animation to each girlfriend variation that has the combo animations (because a character like pixel gf has no combo animation).

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/9d61695c-5ad9-4162-89c0-e2da55bf7869