### PR TITLE
[ENHANCEMENT] Adjust offsets for BF in `phillyTrain` to match `phillyTrainErect`

### DIFF
--- a/preload/data/stages/phillyTrain.json
+++ b/preload/data/stages/phillyTrain.json
@@ -126,7 +126,7 @@
   "characters": {
     "bf": {
       "zIndex": 300,
-      "position": [989.5, 885],
+      "position": [1020.5, 885],
       "cameraOffsets": [-200, -100]
     },
     "dad": {
@@ -143,3 +143,4 @@
   "name": "Philly (Train)",
   "directory": "week3"
 }
+


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6073

<!-- Briefly describe the issue(s) fixed. -->
## Description
Very little offsets fix to the inconsistency between `phillyTrain` and `phillyTrainErect` (The game was unplayable without this fix).
The offsets now are based on `phillyTrainErect`.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Fix:

https://github.com/user-attachments/assets/5a116050-c05c-42c9-a242-56585f8db235

Funny Pico's hand (I didn't take the screenshot at the same frame)