### PR TITLE
[OPTIMIZATION] Clean up ending cutscene logic for Blazin'

### DIFF
--- a/preload/scripts/songs/blazin.hxc
+++ b/preload/scripts/songs/blazin.hxc
@@ -58,17 +58,29 @@ class BlazinSong extends Song
     if (!this.hasHidden)
     {
       this.hasHidden = true;
-      middleScroll();
+      hideOpponentStrumline();
+      centerPlayerStrumline();
     }
   }
 
-  function middleScroll()
+  function hideOpponentStrumline()
+  {
+    if (PlayState.instance.opponentStrumline != null)
+    {
+      for (arrow in PlayState.instance.opponentStrumline.members)
+      {
+        arrow.visible = false;
+      }
+    }
+  }
+
+  function centerPlayerStrumline()
   {
     // This is a song gimmick we are never making middlescroll an option.
-    if (PlayState.instance.opponentStrumline != null)
-      PlayState.instance.opponentStrumline.visible = false;
-    if (PlayState.instance.playerStrumline != null  || !Preferences.controlsScheme == "Arrows" && ControlsHandler.usingExternalInputDevice)
-      PlayState.instance.playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
+    if (Preferences.controlsScheme == "Arrows" && !ControlsHandler.usingExternalInputDevice) return;
+
+    if (playerStrumline != null)
+      playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
   }
 
   public override function onSongEnd(event:CountdownScriptEvent):Void

--- a/preload/scripts/songs/blazin.hxc
+++ b/preload/scripts/songs/blazin.hxc
@@ -79,8 +79,8 @@ class BlazinSong extends Song
     // This is a song gimmick we are never making middlescroll an option.
     if (Preferences.controlsScheme == "Arrows" && !ControlsHandler.usingExternalInputDevice) return;
 
-    if (playerStrumline != null)
-      playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
+    if (PlayState.instance.playerStrumline != null)
+      PlayState.instance.playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
   }
 
   public override function onSongEnd(event:CountdownScriptEvent):Void

--- a/preload/scripts/songs/blazin.hxc
+++ b/preload/scripts/songs/blazin.hxc
@@ -67,7 +67,7 @@ class BlazinSong extends Song
     // This is a song gimmick we are never making middlescroll an option.
     if (PlayState.instance.opponentStrumline != null)
       PlayState.instance.opponentStrumline.visible = false;
-    if (PlayState.instance.playerStrumline != null  || Preferences.controlsScheme == "Arrows" && !ControlsHandler.usingExternalInputDevice)
+    if (PlayState.instance.playerStrumline != null  || !Preferences.controlsScheme == "Arrows" && ControlsHandler.usingExternalInputDevice)
       PlayState.instance.playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
   }
 

--- a/preload/scripts/songs/blazin.hxc
+++ b/preload/scripts/songs/blazin.hxc
@@ -37,11 +37,6 @@ class BlazinSong extends Song
     this.hasHidden = false;
   }
 
-  function onNoteHit(event:HitNoteScriptEvent):Void
-  {
-    super.onNoteHit(event);
-  }
-
   public function listDifficulties(variationId:String, variationIds:Array<String>, showLocked:Bool):Array<String>
   {
     if (showLocked || Save.instance.hasBeatenLevel('weekend1'))
@@ -63,35 +58,17 @@ class BlazinSong extends Song
     if (!this.hasHidden)
     {
       this.hasHidden = true;
-      hideOpponentStrumline();
-      centerPlayerStrumline();
+      middleScroll();
     }
   }
 
-  function hideOpponentStrumline()
-  {
-    var opponentStrumline:FlxSprite = PlayState.instance.opponentStrumline;
-    if (opponentStrumline != null)
-    {
-      for (arrow in opponentStrumline.members)
-      {
-        arrow.visible = false;
-      }
-    }
-  }
-
-  function centerPlayerStrumline()
+  function middleScroll()
   {
     // This is a song gimmick we are never making middlescroll an option.
-
-    if (Preferences.controlsScheme == "Arrows"
-      && !ControlsHandler.usingExternalInputDevice) return;
-
-    var playerStrumline:FlxSprite = PlayState.instance.playerStrumline;
-    if (playerStrumline != null)
-    {
-      playerStrumline.x = FlxG.width / 2 - playerStrumline.width / 2;
-    }
+    if (PlayState.instance.opponentStrumline != null)
+      PlayState.instance.opponentStrumline.visible = false;
+    if (PlayState.instance.playerStrumline != null  || Preferences.controlsScheme == "Arrows" && !ControlsHandler.usingExternalInputDevice)
+      PlayState.instance.playerStrumline.x = FlxG.width / 2 - PlayState.instance.playerStrumline.width / 2;
   }
 
   public override function onSongEnd(event:CountdownScriptEvent):Void
@@ -107,14 +84,8 @@ class BlazinSong extends Song
 
       hasPlayedCutscene = true;
 
-      // Add a black background behind the cutscene to fix a transition bug!
-      trace('Adding black background behind cutscene over UI');
-      var bgSprite = new FunkinSprite(-100, -100);
-      bgSprite.makeSolidColor(2000, 2500, 0xFF000000);
-      bgSprite.cameras = [PlayState.instance.camHUD]; // Show over the HUD.
-      bgSprite.zIndex = 1000000;
-      PlayState.instance.add(bgSprite);
-      PlayState.instance.refresh();
+      PlayState.instance.camGame.visible = false;
+      PlayState.instance.camHUD.visible = false;
 
       event.cancel(); // CANCEL THE COUNTDOWN!
 

--- a/preload/scripts/songs/stress-pico.hxc
+++ b/preload/scripts/songs/stress-pico.hxc
@@ -80,15 +80,8 @@ class StressPicoMixSong extends Song
       PlayState.instance.currentStage.add(tankmanGroup);
       PlayState.instance.currentStage.refresh();
     }
-    else
-    {
+    else 
       trace('Failed to initialize tankman group!');
-    }
-  }
-
-  function onSongStart(event:ScriptEvent):Void
-  {
-    super.onSongStart(event);
   }
 
   function startVideo()
@@ -96,9 +89,7 @@ class StressPicoMixSong extends Song
     var videoPath = 'stressPicoCutscene';
 
     if (Constants.CENSOR_EXPLETIVES)
-    {
       videoPath += '-censored';
-    }
 
     VideoCutscene.play(Paths.videos(videoPath));
   }
@@ -114,9 +105,8 @@ class StressPicoMixSong extends Song
 
     // resets the tankmen!
     if (tankmanGroup != null)
-    {
       tankmanGroup.scriptCall('reset');
-    }
+    
     if (PlayState.instance.currentStage.getGirlfriend() != null)
     {
       PlayState.instance.currentStage.getGirlfriend().scriptCall('reset');
@@ -150,22 +140,11 @@ class StressPicoMixSong extends Song
 
       if (rimlightCamera != null)
       {
-        rimlightCamera.focusOn(new FlxPoint(PlayState.instance.camGame.viewLeft + PlayState.instance.camGame.viewWidth / 2,
-          PlayState.instance.camGame.viewTop + PlayState.instance.camGame.viewHeight / 2));
+        rimlightCamera.focusOn(new FlxPoint(PlayState.instance.camGame.viewLeft + PlayState.instance.camGame.viewWidth / 2, PlayState.instance.camGame.viewTop + PlayState.instance.camGame.viewHeight / 2));
         rimlightCamera.zoom = PlayState.instance.camGame.zoom;
-      }
-
-      if (FlxG.mouse.pressed)
-      {
-        // tankmanCutscene.x = FlxG.mouse.viewX - PlayState.instance.currentStage.getDad().x;
-        //  tankmanCutscene.y = FlxG.mouse.viewY - PlayState.instance.currentStage.getDad().y;
-
-        // trace(tankmanCutscene.x  - PlayState.instance.currentStage.getDad().x, tankmanCutscene.y  - PlayState.instance.currentStage.getDad().y);
       }
     }
   }
-
-  var bgSprite:FunkinSprite;
 
   public override function onSongEnd(event:CountdownScriptEvent):Void
   {
@@ -177,15 +156,7 @@ class StressPicoMixSong extends Song
 
       event.cancel();
 
-      // trace('Adding black background behind cutscene over UI');
-      bgSprite = new FunkinSprite(0, 0);
-      bgSprite.makeSolidColor(2000, 2500, 0xFF000000);
-      bgSprite.cameras = [PlayState.instance.camCutscene]; // Show over the HUD but below the video.
-      // this
-      bgSprite.zIndex = -10000;
-      PlayState.instance.add(bgSprite);
-      PlayState.instance.refresh();
-      bgSprite.alpha = 0;
+
 
       startEndCutscene();
     }
@@ -254,7 +225,7 @@ class StressPicoMixSong extends Song
 
     new FlxTimer(cutsceneTimerManager).start(270 / 24, _ -> {
       PlayState.instance.tweenCameraToPosition(tankmanPos[0] + 320, tankmanPos[1] - 370, 2, FlxEase.quadInOut);
-      FlxTween.tween(bgSprite, {alpha: 1}, 2, null);
+      FlxG.camera.fade(0xFF000000, 2);
     });
 
     new FlxTimer(cutsceneTimerManager).start(320 / 24, _ -> {
@@ -265,12 +236,6 @@ class StressPicoMixSong extends Song
   }
 
   function kill():Void
-  {
-    cleanupTankmanGroup();
-  }
-
-  function cleanupTankmanGroup():Void
-  {
     if (tankmanGroup != null)
     {
       PlayState.instance.currentStage.remove(tankmanGroup);


### PR DESCRIPTION
## Description
Replaces the sprite to camera visible. So ending cutscene will be optimized.
Also removes `onNoteHit()` because he doesn't do anything. Also tested on a mobile, so it works.

