### PR TITLE
[ENHANCEMENT] Remove library from Asset Paths

### DIFF
--- a/preload/data/characters/bf-car.json
+++ b/preload/data/characters/bf-car.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Boyfriend (Car)",
-  "assetPath": "shared:characters/bf-car",
+  "assetPath": "characters/bf-car",
   "renderType": "multianimateatlas",
   "healthIcon": {
     "id": "bf"
@@ -84,26 +84,26 @@
       "prefix": "Hey"
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [18, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [18, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [18, 15]
     },
     {
-      "assetPath": "shared:characters/bfFakeOut",
+      "assetPath": "characters/bfFakeOut",
       "name": "fakeoutDeath",
       "prefix": "fake out death BF",
       "animType": "symbol",

--- a/preload/data/characters/bf-dark.json
+++ b/preload/data/characters/bf-dark.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Boyfriend (Dark)",
   "renderType": "multianimateatlas",
-  "assetPath": "shared:characters/bf-dark",
+  "assetPath": "characters/bf-dark",
   "flipX": true,
   "offsets": [16, 3],
   "cameraOffsets": [-16, 36],
@@ -57,20 +57,20 @@
       "prefix": "Hey"
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [22, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [22, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [22, 15]

--- a/preload/data/characters/bf.json
+++ b/preload/data/characters/bf.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Boyfriend",
   "renderType": "multianimateatlas",
-  "assetPath": "shared:characters/bf",
+  "assetPath": "characters/bf",
   "flipX": true,
   "offsets": [17, 14],
   "cameraOffsets": [-18, 36],
@@ -55,26 +55,26 @@
       "prefix": "Cheer"
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [22, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [22, 15]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [22, 15]
     },
     {
-      "assetPath": "shared:characters/bfFakeOut",
+      "assetPath": "characters/bfFakeOut",
       "name": "fakeoutDeath",
       "prefix": "fake out death BF",
       "animType": "symbol",

--- a/preload/data/characters/dad.json
+++ b/preload/data/characters/dad.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Daddy Dearest",
-  "assetPath": "shared:characters/dad",
+  "assetPath": "characters/dad",
   "renderType": "animateatlas",
   "singTime": 8.0,
   "offsets": [2, 16],

--- a/preload/data/characters/darnell-blazin.json
+++ b/preload/data/characters/darnell-blazin.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Darnell (Blazin')",
-  "assetPath": "shared:characters/darnellBlazin",
+  "assetPath": "characters/darnellBlazin",
   "healthIcon": {
     "id": "darnell"
   },

--- a/preload/data/characters/darnell.json
+++ b/preload/data/characters/darnell.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Darnell",
-  "assetPath": "shared:characters/darnell",
+  "assetPath": "characters/darnell",
   "renderType": "animateatlas",
   "offsets": [18, 31],
   "cameraOffsets": [-18, 4],

--- a/preload/data/characters/gf-car.json
+++ b/preload/data/characters/gf-car.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Girlfriend (Car)",
-  "assetPath": "shared:characters/gfCar",
+  "assetPath": "characters/gfCar",
   "renderType": "animateatlas",
   "startingAnimation": "danceRight",
   "offsets": [0, 0],

--- a/preload/data/characters/gf-christmas.json
+++ b/preload/data/characters/gf-christmas.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Girlfriend (Christmas)",
-  "assetPath": "shared:characters/gf-christmas",
+  "assetPath": "characters/gf-christmas",
   "renderType": "animateatlas",
   "startingAnimation": "danceRight",
   "offsets": [-1, 5],

--- a/preload/data/characters/gf-dark.json
+++ b/preload/data/characters/gf-dark.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Girlfriend (Dark)",
   "renderType": "animateatlas",
-  "assetPath": "shared:characters/gf-dark",
+  "assetPath": "characters/gf-dark",
   "startingAnimation": "danceRight",
   "offsets": [-12, 4],
   "cameraOffsets": [12, 8],

--- a/preload/data/characters/gf.json
+++ b/preload/data/characters/gf.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Girlfriend",
   "renderType": "animateatlas",
-  "assetPath": "shared:characters/gf",
+  "assetPath": "characters/gf",
   "startingAnimation": "danceRight",
   "offsets": [-12, 4],
   "cameraOffsets": [12, 8],

--- a/preload/data/characters/mom-car.json
+++ b/preload/data/characters/mom-car.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Mommy Mearest (Car)",
-  "assetPath": "shared:characters/momCar",
+  "assetPath": "characters/momCar",
   "renderType": "animateatlas",
   "singTime": 8.0,
   "healthIcon": {

--- a/preload/data/characters/monster-christmas.json
+++ b/preload/data/characters/monster-christmas.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Monster (Christmas)",
-  "assetPath": "shared:characters/monster",
+  "assetPath": "characters/monster",
   "healthIcon": {
     "id": "monster"
   },

--- a/preload/data/characters/monster.json
+++ b/preload/data/characters/monster.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Monster",
-  "assetPath": "shared:characters/monster",
+  "assetPath": "characters/monster",
   "renderType": "animateatlas",
   "offsets": [0, 1],
   "cameraOffsets": [0, 29],

--- a/preload/data/characters/nene-christmas.json
+++ b/preload/data/characters/nene-christmas.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Nene (Christmas)",
-  "assetPath": "shared:characters/nene-christmas",
+  "assetPath": "characters/nene-christmas",
   "startingAnimation": "danceRight",
   "renderType": "animateatlas",
   "offsets": [-16, -89],

--- a/preload/data/characters/nene-dark.json
+++ b/preload/data/characters/nene-dark.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Nene (Dark)",
-  "assetPath": "shared:characters/nene-dark",
+  "assetPath": "characters/nene-dark",
   "startingAnimation": "danceRight",
   "renderType": "animateatlas",
   "offsets": [4, -89],

--- a/preload/data/characters/nene-tankmen.json
+++ b/preload/data/characters/nene-tankmen.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Nene (Tankman Stickup)",
-  "assetPath": "shared:characters/nene",
+  "assetPath": "characters/nene",
   "startingAnimation": "danceRight",
   "renderType": "animateatlas",
   "offsets": [-44, -67],

--- a/preload/data/characters/nene.json
+++ b/preload/data/characters/nene.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Nene",
-  "assetPath": "shared:characters/nene",
+  "assetPath": "characters/nene",
   "startingAnimation": "danceRight",
   "renderType": "animateatlas",
   "offsets": [4, -89],

--- a/preload/data/characters/otis-speaker.json
+++ b/preload/data/characters/otis-speaker.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Otis (Speaker Shooter)",
-  "assetPath": "shared:characters/otis",
+  "assetPath": "characters/otis",
   "startingAnimation": "idle",
   "renderType": "animateatlas",
   "singTime": 4.0,

--- a/preload/data/characters/parents-christmas.json
+++ b/preload/data/characters/parents-christmas.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Mommy and Daddy (Festive)",
   "renderType": "animateatlas",
-  "assetPath": "shared:characters/parents-christmas",
+  "assetPath": "characters/parents-christmas",
   "offsets": [1, 9],
   "cameraOffsets": [-1, 10],
   "animations": [

--- a/preload/data/characters/pico-blazin.json
+++ b/preload/data/characters/pico-blazin.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico (Blazin')",
-  "assetPath": "shared:characters/picoBlazin",
+  "assetPath": "characters/picoBlazin",
   "healthIcon": {
     "id": "pico"
   },

--- a/preload/data/characters/pico-dark.json
+++ b/preload/data/characters/pico-dark.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico (Dark)",
-  "assetPath": "shared:characters/pico-dark",
+  "assetPath": "characters/pico-dark",
   "healthIcon": {
     "id": "pico",
     "flipX": false
@@ -55,20 +55,20 @@
       "prefix": "Right Miss"
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [100, 195]
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [100, 195]
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [100, 195]

--- a/preload/data/characters/pico-holding-nene.json
+++ b/preload/data/characters/pico-holding-nene.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico (Holding Nene)",
-  "assetPath": "shared:characters/pico-holding-nene",
+  "assetPath": "characters/pico-holding-nene",
   "healthIcon": {
     "id": "pico"
   },
@@ -63,26 +63,26 @@
       "looped": true
     },
     {
-      "assetPath": "shared:characters/pico-holding-nene/picoAndNene-DEAD",
+      "assetPath": "characters/pico-holding-nene/picoAndNene-DEAD",
       "name": "firstDeath",
       "prefix": "intro",
       "offsets": [543, 0]
     },
     {
-      "assetPath": "shared:characters/pico-holding-nene/picoAndNene-DEAD",
+      "assetPath": "characters/pico-holding-nene/picoAndNene-DEAD",
       "name": "deathLoop",
       "prefix": "loop",
       "looped": true,
       "offsets": [543, 0]
     },
     {
-      "assetPath": "shared:characters/pico-holding-nene/picoAndNene-DEAD",
+      "assetPath": "characters/pico-holding-nene/picoAndNene-DEAD",
       "name": "deathConfirm",
       "prefix": "confirm",
       "offsets": [543, 0]
     },
     {
-      "assetPath": "shared:characters/pico-holding-nene/picoAndNene-DEAD",
+      "assetPath": "characters/pico-holding-nene/picoAndNene-DEAD",
       "name": "deathConfirm-loop",
       "prefix": "confirm loop",
       "looped": true,

--- a/preload/data/characters/pico-playable.json
+++ b/preload/data/characters/pico-playable.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico (Playable)",
-  "assetPath": "shared:characters/pico/basic-animations",
+  "assetPath": "characters/pico/basic-animations",
   "healthIcon": {
     "id": "pico",
     "flipX": false
@@ -64,123 +64,123 @@
       "offsets": [-28, -75]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "singLEFTmiss",
       "prefix": "Left Miss",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "singDOWNmiss",
       "prefix": "Down Miss",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "singUPmiss",
       "prefix": "Up Miss",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "singRIGHTmiss",
       "prefix": "Right Miss",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "shootMISS",
       "prefix": "Hit",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [100, 195]
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [100, 195]
     },
     {
-      "assetPath": "shared:characters/pico/death",
+      "assetPath": "characters/pico/death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [100, 195]
     },
     {
-      "assetPath": "shared:characters/pico/explosion-death",
+      "assetPath": "characters/pico/explosion-death",
       "name": "firstDeath-explosion",
       "prefix": "intro",
       "offsets": [335, 990]
     },
     {
-      "assetPath": "shared:characters/pico/explosion-death",
+      "assetPath": "characters/pico/explosion-death",
       "name": "deathLoop-explosion",
       "prefix": "Loop Start",
       "looped": true,
       "offsets": [335, 990]
     },
     {
-      "assetPath": "shared:characters/pico/explosion-death",
+      "assetPath": "characters/pico/explosion-death",
       "name": "deathConfirm-explosion",
       "prefix": "Confirm",
       "offsets": [335, 990]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "hey",
       "prefix": "Hey",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "cheer",
       "prefix": "Cheer",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "cock",
       "prefix": "Gun Reload",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "shoot",
       "prefix": "Shoot",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "intro1",
       "prefix": "Pissed Off",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "intro2",
       "prefix": "Shoot and Return",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "burpShit",
       "prefix": "*BURP* ... Shit",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "burpSmile",
       "prefix": "Burp Smile",
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "burpSmileLong",
       "prefix": "Burp Smile",
       "frameIndices": [
@@ -192,7 +192,7 @@
       "offsets": [138, 168]
     },
     {
-      "assetPath": "shared:characters/pico/playable-animations",
+      "assetPath": "characters/pico/playable-animations",
       "name": "shit",
       "prefix": "Burp Censor",
       "offsets": [138, 168]

--- a/preload/data/characters/pico-speaker.json
+++ b/preload/data/characters/pico-speaker.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico (Speaker Shooter)",
-  "assetPath": "shared:characters/pico-speaker",
+  "assetPath": "characters/pico-speaker",
   "renderType": "animateatlas",
   "offsets": [39, 6],
   "cameraOffsets": [86, 8],

--- a/preload/data/characters/pico.json
+++ b/preload/data/characters/pico.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Pico",
-  "assetPath": "shared:characters/pico/basic-animations",
+  "assetPath": "characters/pico/basic-animations",
   "renderType": "animateatlas",
   "flipX": true,
   "offsets": [-23, 1],

--- a/preload/data/characters/sserafim-chaewon.json
+++ b/preload/data/characters/sserafim-chaewon.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Kim Chaewon",
-  "assetPath": "shared:characters/sserafim/chaewon",
+  "assetPath": "characters/sserafim/chaewon",
   "renderType": "animateatlas",
   "healthIcon": {
     "id": "bf"

--- a/preload/data/characters/sserafim-eunchae.json
+++ b/preload/data/characters/sserafim-eunchae.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Hong Eunchae",
-  "assetPath": "shared:characters/sserafim/eunchae",
+  "assetPath": "characters/sserafim/eunchae",
   "renderType": "animateatlas",
   "healthIcon": {
     "id": "bf"

--- a/preload/data/characters/sserafim-gf.json
+++ b/preload/data/characters/sserafim-gf.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Girlfriend (SSERAFIM)",
-  "assetPath": "shared:characters/sserafim/sserafim-gf",
+  "assetPath": "characters/sserafim/sserafim-gf",
   "renderType": "animateatlas",
   "healthIcon": {
     "id": "gf"

--- a/preload/data/characters/sserafim-kazuha.json
+++ b/preload/data/characters/sserafim-kazuha.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Kazuha",
-  "assetPath": "shared:characters/sserafim/kazuha",
+  "assetPath": "characters/sserafim/kazuha",
   "renderType": "animateatlas",
   "healthIcon": {
     "id": "kazuha",

--- a/preload/data/characters/sserafim-sakura.json
+++ b/preload/data/characters/sserafim-sakura.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Sakura",
-  "assetPath": "shared:characters/sserafim/sakura",
+  "assetPath": "characters/sserafim/sakura",
   "renderType": "multianimateatlas",
   "healthIcon": {
     "id": "bf"
@@ -158,20 +158,20 @@
       "offsets": [0, 0]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "firstDeath",
       "prefix": "Death Intro",
       "offsets": [20, -220]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathLoop",
       "prefix": "Death Loop",
       "looped": true,
       "offsets": [20, -220]
     },
     {
-      "assetPath": "shared:characters/bf-death",
+      "assetPath": "characters/bf-death",
       "name": "deathConfirm",
       "prefix": "Death Confirm",
       "offsets": [20, -220]

--- a/preload/data/characters/sserafim-yunjin.json
+++ b/preload/data/characters/sserafim-yunjin.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "name": "Huh Yunjin",
-  "assetPath": "shared:characters/sserafim/yunjin",
+  "assetPath": "characters/sserafim/yunjin",
   "renderType": "animateatlas",
   "healthIcon": {
     "id": "bf"

--- a/preload/data/characters/tankman-bloody.json
+++ b/preload/data/characters/tankman-bloody.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Tankman (Bloody)",
   "renderType": "multianimateatlas",
-  "assetPath": "shared:characters/tankman/basic",
+  "assetPath": "characters/tankman/basic",
   "offsets": [3, -44],
   "cameraOffsets": [-3, 32],
   "healthIcon": {
@@ -30,43 +30,43 @@
       "prefix": "right"
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "idle-bloody",
       "prefix": "idle knife",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "singLEFT-bloody",
       "prefix": "left knife",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "singDOWN-bloody",
       "prefix": "down knife",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "singUP-bloody",
       "prefix": "up knife",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "singRIGHT-bloody",
       "prefix": "right knife",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "hehPrettyGood-bloody",
       "prefix": "pretty good bloody",
       "offsets": [67, 110]
     },
     {
-      "assetPath": "shared:characters/tankman/bloody",
+      "assetPath": "characters/tankman/bloody",
       "name": "redheadsAnim",
       "prefix": "redheads",
       "offsets": [67, 110]

--- a/preload/data/characters/tankman.json
+++ b/preload/data/characters/tankman.json
@@ -2,7 +2,7 @@
   "version": "1.0.0",
   "name": "Tankman",
   "renderType": "multianimateatlas",
-  "assetPath": "shared:characters/tankman/basic",
+  "assetPath": "characters/tankman/basic",
   "offsets": [3, -44],
   "cameraOffsets": [-3, 32],
   "animations": [
@@ -27,31 +27,31 @@
       "prefix": "right"
     },
     {
-      "assetPath": "shared:characters/tankman/extra-animations",
+      "assetPath": "characters/tankman/extra-animations",
       "name": "hehPrettyGood",
       "prefix": "pretty good",
       "offsets": [5, -40]
     },
     {
-      "assetPath": "shared:characters/tankman/extra-animations",
+      "assetPath": "characters/tankman/extra-animations",
       "name": "ugh",
       "prefix": "ugh",
       "offsets": [5, -40]
     },
     {
-      "assetPath": "shared:characters/tankman/extra-animations",
+      "assetPath": "characters/tankman/extra-animations",
       "name": "laugh",
       "prefix": "laugh",
       "offsets": [5, -40]
     },
     {
-      "assetPath": "shared:characters/tankman/extra-animations",
+      "assetPath": "characters/tankman/extra-animations",
       "name": "beat it",
       "prefix": "beat it",
       "offsets": [5, -40]
     },
     {
-      "assetPath": "shared:characters/tankman/extra-animations",
+      "assetPath": "characters/tankman/extra-animations",
       "name": "augh",
       "prefix": "argh",
       "offsets": [5, -40]

--- a/preload/data/players/bf.json
+++ b/preload/data/players/bf.json
@@ -119,7 +119,7 @@
       },
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsPERFECT/hearts",
+        "assetPath": "resultScreen/results-bf/resultsPERFECT/hearts",
         "filter": "naughty",
         "zIndex": 501,
         "delay": 4.41,
@@ -137,7 +137,7 @@
       },
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsPERFECT/tickleFight",
+        "assetPath": "resultScreen/results-bf/resultsPERFECT/tickleFight",
         "filter": "safe",
         "zIndex": 501,
         "delay": 4.41,
@@ -159,7 +159,7 @@
       },
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsPERFECT/hearts",
+        "assetPath": "resultScreen/results-bf/resultsPERFECT/hearts",
         "filter": "naughty",
         "zIndex": 501,
         "delay": 4.41,
@@ -177,7 +177,7 @@
       },
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsPERFECT/tickleFight",
+        "assetPath": "resultScreen/results-bf/resultsPERFECT/tickleFight",
         "filter": "safe",
         "zIndex": 501,
         "delay": 4.41,
@@ -190,7 +190,7 @@
     "excellent": [
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsEXCELLENT",
+        "assetPath": "resultScreen/results-bf/resultsEXCELLENT",
         "zIndex": 500,
         "offsets": [560.85, -410.35],
         "loopFrame": 29
@@ -199,7 +199,7 @@
     "great": [
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsGREAT/gf",
+        "assetPath": "resultScreen/results-bf/resultsGREAT/gf",
         "scale": 0.93,
         "delay": 0.25,
         "offsets": [563.364, -123.186],
@@ -209,7 +209,7 @@
       },
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsGREAT/bf",
+        "assetPath": "resultScreen/results-bf/resultsGREAT/bf",
         "scale": 0.93,
         "zIndex": 500,
         "offsets": [655.3, -247.95],
@@ -220,14 +220,14 @@
     "good": [
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-bf/resultsGOOD/bf",
+        "assetPath": "resultScreen/results-bf/resultsGOOD/bf",
         "zIndex": 501,
         "offsets": [645.4, -214.8],
         "loopFrame": 14
       },
       {
         "renderType": "sparrow",
-        "assetPath": "shared:resultScreen/results-bf/resultsGOOD/resultGirlfriendGOOD",
+        "assetPath": "resultScreen/results-bf/resultsGOOD/resultGirlfriendGOOD",
         "zIndex": 500,
         "delay": 0.91,
         "offsets": [629, 323],

--- a/preload/data/players/pico.json
+++ b/preload/data/players/pico.json
@@ -144,7 +144,7 @@
     "loss": [
       {
         "renderType": "animateatlas",
-        "assetPath": "shared:resultScreen/results-pico/resultsSHIT",
+        "assetPath": "resultScreen/results-pico/resultsSHIT",
         "zIndex": 500,
         "offsets": [-50, 60],
         "loopFrame": 0

--- a/preload/scripts/characters/nene.hxc
+++ b/preload/scripts/characters/nene.hxc
@@ -190,7 +190,7 @@ class NeneBaseCharacter extends AnimateAtlasCharacter
 
     eyeWhites = new FunkinSprite().makeSolidColor(160, 60);
 
-    pupil = FunkinSprite.createTextureAtlas(0, 0, "characters/abot/systemEyes", "shared");
+    pupil = FunkinSprite.createTextureAtlas(0, 0, "characters/abot/systemEyes");
     pupil.x = this.x;
     pupil.y = this.y;
     pupil.zIndex = this.zIndex - 5;

--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -61,7 +61,7 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
 
     eyeWhites = new FunkinSprite().makeSolidColor(160, 60);
 
-    pupil = FunkinSprite.createTextureAtlas(0, 0, "characters/abot/systemEyes", "shared");
+    pupil = FunkinSprite.createTextureAtlas(0, 0, "characters/abot/systemEyes");
     pupil.x = this.x;
     pupil.y = this.y;
     pupil.zIndex = this.zIndex - 5;

--- a/preload/scripts/players/results/bf/BFBedPerfectResults.hxc
+++ b/preload/scripts/players/results/bf/BFBedPerfectResults.hxc
@@ -8,7 +8,7 @@ class BFBedPerfectResults extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("resultScreen/results-bf/resultsPERFECT/bed", "shared");
+    loadTextureAtlas("resultScreen/results-bf/resultsPERFECT/bed");
 
     anim.onFrameChange.add((animation:String, frame:Int) -> {
       if (!HapticUtil.hapticsAvailable) return;

--- a/preload/scripts/players/results/bf/BFShitResults.hxc
+++ b/preload/scripts/players/results/bf/BFShitResults.hxc
@@ -8,7 +8,7 @@ class BFShitResults extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("resultScreen/results-bf/resultsSHIT", "shared");
+    loadTextureAtlas("resultScreen/results-bf/resultsSHIT");
 
     anim.onFrameChange.add((animation:String, frame:Int) -> {
       if (!HapticUtil.hapticsAvailable) return;

--- a/preload/scripts/players/results/pico/PicoGoodResults.hxc
+++ b/preload/scripts/players/results/pico/PicoGoodResults.hxc
@@ -14,7 +14,7 @@ class PicoGoodResults extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("resultScreen/results-pico/resultsGOOD", "shared");
+    loadTextureAtlas("resultScreen/results-pico/resultsGOOD");
     scaleFlashes();
 
     animation.onFrameChange.add((animation:String, frame:Int) -> {

--- a/preload/scripts/players/results/pico/PicoGreatResults.hxc
+++ b/preload/scripts/players/results/pico/PicoGreatResults.hxc
@@ -14,7 +14,7 @@ class PicoGreatResults extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("resultScreen/results-pico/resultsGREAT", "shared");
+    loadTextureAtlas("resultScreen/results-pico/resultsGREAT");
     scaleFlashes();
 
     animation.onFrameChange.add((animation:String, frame:Int) -> {

--- a/preload/scripts/players/results/pico/PicoPerfectResults.hxc
+++ b/preload/scripts/players/results/pico/PicoPerfectResults.hxc
@@ -8,7 +8,7 @@ class PicoPerfectResults extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("resultScreen/results-pico/resultsPERFECT", "shared");
+    loadTextureAtlas("resultScreen/results-pico/resultsPERFECT");
 
     anim.onFrameChange.add((animation:String, frame:Int) -> {
       if (!HapticUtil.hapticsAvailable) return;

--- a/preload/scripts/stages/props/ABotAtlasSprite.hxc
+++ b/preload/scripts/stages/props/ABotAtlasSprite.hxc
@@ -8,6 +8,6 @@ class ABotAtlasSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("characters/abot/abotSystem", "shared");
+    loadTextureAtlas("characters/abot/abotSystem");
   }
 }

--- a/preload/scripts/stages/props/DadShootsSprite.hxc
+++ b/preload/scripts/stages/props/DadShootsSprite.hxc
@@ -11,7 +11,7 @@ class DadShootsSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("christmas/parents_shoot_assets", "week5");
+    loadTextureAtlas("christmas/parents_shoot_assets");
   }
 
   public function playCutscene():Void

--- a/preload/scripts/stages/props/PicoBloodPool.hxc
+++ b/preload/scripts/stages/props/PicoBloodPool.hxc
@@ -8,7 +8,7 @@ class PicoBloodPool extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("philly/erect/bloodPool", "week3");
+    loadTextureAtlas("philly/erect/bloodPool");
 
     animation.onFinish.addOnce((_) -> {
       extendBloodPool = true;

--- a/preload/scripts/stages/props/PicoDopplegangerSprite.hxc
+++ b/preload/scripts/stages/props/PicoDopplegangerSprite.hxc
@@ -18,7 +18,7 @@ class PicoDopplegangerSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("philly/erect/pico_doppleganger", "week3");
+    loadTextureAtlas("philly/erect/pico_doppleganger");
   }
 
   var cutsceneSounds:FunkinSound = null;

--- a/preload/scripts/stages/props/SantaDiesSprite.hxc
+++ b/preload/scripts/stages/props/SantaDiesSprite.hxc
@@ -10,7 +10,7 @@ class SantaDiesSprite extends FunkinSprite
   public function new(x:Float, y:Float)
   {
     super(x, y);
-    loadTextureAtlas("christmas/santa_speaks_assets", "week5");
+    loadTextureAtlas("christmas/santa_speaks_assets");
   }
 
   public function playCutscene():Void

--- a/preload/scripts/stages/props/SpraycanAtlasSprite.hxc
+++ b/preload/scripts/stages/props/SpraycanAtlasSprite.hxc
@@ -15,7 +15,7 @@ class SpraycanAtlasSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("spraycanAtlas", "weekend1",
+    loadTextureAtlas("spraycanAtlas", null,
       {
         swfMode: true
       });

--- a/preload/scripts/stages/props/SserafimBfSprite.hxc
+++ b/preload/scripts/stages/props/SserafimBfSprite.hxc
@@ -7,7 +7,7 @@ class SserafimBfSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("cutscene/bfGetUp", "sserafim");
+    loadTextureAtlas("cutscene/bfGetUp");
   }
 
   public function resetAnim():Void

--- a/preload/scripts/stages/props/SserafimCutsceneSprite.hxc
+++ b/preload/scripts/stages/props/SserafimCutsceneSprite.hxc
@@ -7,7 +7,7 @@ class SserafimCutsceneSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("cutscene/cutsceneMain", "sserafim");
+    loadTextureAtlas("cutscene/cutsceneMain");
   }
 
   public function doAnim():Void

--- a/preload/scripts/stages/props/SserafimGfSprite.hxc
+++ b/preload/scripts/stages/props/SserafimGfSprite.hxc
@@ -7,7 +7,7 @@ class SserafimGfSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas("cutscene/gfGetUp", "sserafim",
+    loadTextureAtlas("cutscene/gfGetUp", null,
       {
         cacheOnLoad: true
       });

--- a/preload/scripts/stages/props/SserafimLipSyncSprite.hxc
+++ b/preload/scripts/stages/props/SserafimLipSyncSprite.hxc
@@ -29,7 +29,7 @@ class SserafimLipSyncSprite extends FunkinSprite
   {
     super(x, y);
 
-    loadTextureAtlas(suffix != null ? 'sserafim-lipsync-' + suffix : 'sserafim-lipsync', "sserafim");
+    loadTextureAtlas(suffix != null ? 'sserafim-lipsync-' + suffix : 'sserafim-lipsync');
     animation.addBySymbol("lipsync", this.getDefaultSymbol(), 24, false);
     animation.play("lipsync", true);
   }


### PR DESCRIPTION
<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
### This Assets PR doesn't need to be merged for the associated PR to work, it is purely optional.
FunkinCrew/Funkin#6622

<!-- Does this PR close any issues? If so, link them below. -->
<!-- ## Linked Issues -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR removes the `library` off of asset paths, since `Paths.animateAtlas` now automatically searches for them.
