### PR TITLE
[BUGFIX] prevent GF hairFall animation on song retry

### DIFF
--- a/preload/scripts/stages/phillyTrain.hxc
+++ b/preload/scripts/stages/phillyTrain.hxc
@@ -3,7 +3,6 @@ import flixel.FlxSprite;
 import flixel.addons.display.FlxRuntimeShader;
 import funkin.audio.FunkinSound;
 import funkin.Conductor;
-import funkin.modding.base.ScriptedFlxRuntimeShader;
 import funkin.play.PlayState;
 import funkin.play.stage.Stage;
 import funkin.util.HapticUtil;
@@ -15,13 +14,7 @@ class PhillyTrainStage extends Stage
     super('phillyTrain');
   }
 
-  var lightColors:Array<FlxColor> = [
-    0xFF31A2FD,
-    0xFF31FD8C,
-    0xFFFB33F5,
-    0xFFFBA633,
-    0xFFFD4531
-  ];
+  var lightColors:Array<FlxColor> = [0xFF31A2FD, 0xFF31FD8C, 0xFFFB33F5, 0xFFFBA633, 0xFFFD4531];
 
   var lightWindow:FlxSprite;
   var lightShader:FlxRuntimeShader;
@@ -35,7 +28,7 @@ class PhillyTrainStage extends Stage
     trainEnabled = true;
 
     // NOTE: You pass the constructor variables directly, not as an array.
-    lightShader = ScriptedFlxRuntimeShader.init('BuildingEffectShader', 1.0);
+    lightShader = new BuildingEffectShader(1.0);
     trainSound = FunkinSound.load(Paths.sound('train_passes'), 1.0, false, false, false);
     PlayState.instance.add(trainSound); // Sounds need to be added to the scene for update() to work
 
@@ -61,7 +54,7 @@ class PhillyTrainStage extends Stage
     super.onUpdate(event);
     // Update beat lights
     var shaderInput:Float = (Conductor.instance.beatLengthMs / 1000) * event.elapsed * 1.5;
-    lightShader.scriptCall('update', [shaderInput]);
+    lightShader.update(shaderInput);
 
     // Update train
     if (trainEnabled && trainMoving)
@@ -96,7 +89,7 @@ class PhillyTrainStage extends Stage
     if (event.beat % 4 == 0)
     {
       // Reset opacity
-      lightShader.scriptCall('reset');
+      lightShader.reset();
 
       // Switch to a different light
       curLight = FlxG.random.int(0, lightColors.length - 1);
@@ -160,6 +153,15 @@ class PhillyTrainStage extends Stage
 
   function trainReset():Void
   {
+    /**
+     * FIX: Only play hairFall if the train actually started moving.
+     * On a restart, startedMoving will be false, so this will be skipped.
+     */
+    if (startedMoving)
+    {
+      getGirlfriend().playAnimation('hairFall');
+    }
+
     getGirlfriend().playAnimation('hairFall');
     getNamedProp('train').x = FlxG.width + 200;
 
@@ -176,6 +178,18 @@ class PhillyTrainStage extends Stage
   {
     super.onSongRetry(event);
     trainReset();
+
+    // Force GF to reset to her idle dance immediately.
+    if (getGirlfriend() != null)
+    {
+      getGirlfriend().playAnimation('danceLeft', true);
+    }
+
+    // Stop the tain sound so it doensn't bleed into the restart.
+    if (trainSound != null)
+    {
+      trainSound.stop();
+    }
   }
 
   function kill()

--- a/preload/scripts/stages/phillyTrain.hxc
+++ b/preload/scripts/stages/phillyTrain.hxc
@@ -182,7 +182,7 @@ class PhillyTrainStage extends Stage
     // Force GF to reset to her idle dance immediately.
     if (getGirlfriend() != null)
     {
-      getGirlfriend().playAnimation('danceLeft', true);
+      getGirlfriend().dance(true);
     }
 
     // Stop the tain sound so it doensn't bleed into the restart.

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -554,6 +554,11 @@ class PhillyTrainErectStage extends Stage
         getGirlfriend().playAnimation('hairFall');
     }
 
+    if (startedMoving)
+    {
+      getGirlfriend().playAnimation('hairFall');
+    }
+
     trainMoving = false;
     trainCars = 8;
     trainFinishing = false;
@@ -564,6 +569,16 @@ class PhillyTrainErectStage extends Stage
   {
     super.onSongRetry(event);
     trainReset();
+
+    if (getGirlfriend() != null)
+    {
+      getGirlfriend().dance(true);
+    }
+
+    if (trainSound != null)
+    {
+      trainSound.stop();
+    }
   }
 
   public override function onSongEnd(event:CountdownScriptEvent):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Closes [#6749](https://github.com/FunkinCrew/Funkin/issues/6749) (Girlfriend's hairFall animation plays after restarting in Philly Train stages)

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR addresses a visual bug where GF's `hairFall` animation would trigger immediately upon restarting the song in `PhillyTrain.hxc`

### Changes
-  Added a check in  `trainReset()` so hairFall only plays if startedMoving is true.
-  Added `getGirlfriend.dance(true)` to onSongRetry to force a clean transition when restarting.
-  Included a`trainSound.stop()` call in the retry sequence to prevent the train whistle from carrying over into the next attempt.
- Ensured all train-related variables are fully cleared during the restart process.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Original Bug Report
https://github.com/user-attachments/assets/44f3549e-cb1a-4523-af64-79ce64c40098

### Bug Fix
https://github.com/user-attachments/assets/f73786e2-61c7-4b10-abc6-9c1e53e22c14

**Applied these fixes to the erect stages also**:

https://github.com/user-attachments/assets/166a5d5b-bf77-44a0-a795-d763c408c195
