### PR TITLE
[BUGFIX] Fix dying on the same frame as the lighting strikes in the Week 2 Remix stage throwing an error

### DIFF
--- a/preload/scripts/stages/spookyMansionErect.hxc
+++ b/preload/scripts/stages/spookyMansionErect.hxc
@@ -86,7 +86,7 @@ class SpookyMansionErectStage extends Stage
     {
       getNamedProp('bgLight').alpha = 0;
       getNamedProp('stairsLight').alpha = 0;
-      getBoyfriend().alpha = 1;
+      getBoyfriend()?.alpha ??= 1;
       getDad().alpha = 1;
       getGirlfriend().alpha = 1;
     });
@@ -95,12 +95,12 @@ class SpookyMansionErectStage extends Stage
     {
       getNamedProp('bgLight').alpha = 1;
       getNamedProp('stairsLight').alpha = 1;
-      getBoyfriend().alpha = 0;
+      getBoyfriend()?.alpha ??= 0;
       getDad().alpha = 0;
       getGirlfriend().alpha = 0;
       FlxTween.tween(getNamedProp('bgLight'), {alpha: 0}, 1.5);
       FlxTween.tween(getNamedProp('stairsLight'), {alpha: 0}, 1.5);
-      FlxTween.tween(getBoyfriend(), {alpha: 1}, 1.5);
+      if (getBoyfriend() != null) FlxTween.tween(getBoyfriend(), {alpha: 1}, 1.5);
       FlxTween.tween(getDad(), {alpha: 1}, 1.5);
       FlxTween.tween(getGirlfriend(), {alpha: 1}, 1.5);
     });
@@ -108,7 +108,7 @@ class SpookyMansionErectStage extends Stage
     lightningStrikeBeat = beat;
     lightningStrikeOffset = FlxG.random.int(8, 24);
 
-    if (getBoyfriend().hasAnimation('scared') && getBoyfriend().animation.name != 'cheer')
+    if (getBoyfriend() != null && getBoyfriend().hasAnimation('scared') && getBoyfriend().animation.name != 'cheer')
     {
       getBoyfriend().playAnimation('scared', true, true);
     }
@@ -201,5 +201,13 @@ class SpookyMansionErectStage extends Stage
     // Reset lightning variables at the start of every song
     lightningStrikeBeat = 0;
     lightningStrikeOffset = 8;
+  }
+
+  function onGameOver(event:ScriptEvent)
+  {
+    super.onGameOver(event);
+
+    // Make sure the player character is visible when dying on the same frame as the lightning strikes.
+    getBoyfriend().alpha = 1;
   }
 }


### PR DESCRIPTION
## Associated Funkin PR
N/A

## Linked Issues
Closes https://github.com/FunkinCrew/Funkin/issues/6960

## Description
When dying, Boyfriend is removed from the stage, meaning `getBoyfriend()` returns NOTHING !!!
Sorry gang it took a bit more than 4 lines cause i had to reset the visibility 💔 

## Screenshots/Videos

https://github.com/user-attachments/assets/642f49c7-8893-40bc-90c8-3f463cc65f6d

For the footage i had to slightly edit the script so that I could consistently die on the frame of the lightning strike happening.
