### PR TITLE
[BUGFIX] Implement reset for Tankman and Pico animations on song restart

### DIFF
--- a/preload/scripts/songs/stress-pico.hxc
+++ b/preload/scripts/songs/stress-pico.hxc
@@ -113,6 +113,18 @@ class StressPicoMixSong extends Song
       PlayState.instance.currentStage?.getGirlfriend().reset();
       trace('reset pico!');
     }
+
+    // Resets Tankman and Pico if they were in the middle of the "redheads" sequence.
+    if (PlayState.instance.currentStage?.getDad().getCurrentAnimation() == 'redheadsAnim')
+    {
+      PlayState.instance.currentStage?.getDad().canPlayOtherAnims = true;
+      PlayState.instance.currentStage?.getDad().dance(true);
+    }
+    if (PlayState.instance.currentStage?.getBoyfriend().getCurrentAnimation() == 'knifeToss')
+    {
+      PlayState.instance.currentStage?.getBoyfriend().canPlayOtherAnims = true;
+      PlayState.instance.currentStage?.getBoyfriend().dance(true);
+    }
   }
 
   /**


### PR DESCRIPTION
Add reset logic for Tankman and Pico during 'redheads' sequence if a restart is triggered.

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
[Issue #6800](https://github.com/FunkinCrew/Funkin/issues/6800)
<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds logic that makes sure that the animations(`redheadsAnim` and `knifeToss`) that play during the "Ugh, redheads!" sequence of Stress(Pico Mix) do not continue playing when the song restarts or the player dies.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before:

https://github.com/user-attachments/assets/6216f981-4f24-4b58-8b06-dff4da3352af

### After:

https://github.com/user-attachments/assets/e72958c6-cc33-4c8f-b21b-2b36f4240be3
