### PR TITLE
[BUGFIX] Fix Pico & Nene Dark throwing an error when trying to set its alpha

### DIFF
--- a/preload/scripts/characters/nene-dark.hxc
+++ b/preload/scripts/characters/nene-dark.hxc
@@ -21,9 +21,12 @@ class NeneDarkCharacter extends NeneBaseCharacter
 
     abotTextureSwap.amount = val;
 
-    if (val != 1) normalChar.alpha = 1;
-    else
-      normalChar.alpha = 0;
+    if (normalChar != null)
+    {
+      if (val != 1) normalChar.alpha = 1;
+      else
+        normalChar.alpha = 0.0001;
+    }
 
     eyeWhites.color = FlxColorUtil.interpolate(0xFFFFFFFF, 0xFF6F96CE, val);
 

--- a/preload/scripts/characters/pico-dark.hxc
+++ b/preload/scripts/characters/pico-dark.hxc
@@ -24,9 +24,12 @@ class PicoDarkCharacter extends PicoPlayerBaseCharacter
   {
     super.set_alpha(val);
 
-    if (val != 1) normalChar.alpha = 1;
-    else
-      normalChar.alpha = 0;
+    if (normalChar != null)
+    {
+      if (val != 1) normalChar.alpha = 1;
+      else
+        normalChar.alpha = 0.0001;
+    }
 
     return val;
   }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None, but was mentioned on the Discord server

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR adds in a missing check for if `normalChar` is null in `function set_alpha`, which is present in the other dark characters except for both Pico & Nene's dark variants