### PR TITLE
[BUGFIX] Fix Dark A-Bot not loading its dark textures

### DIFF
--- a/preload/scripts/characters/nene-dark.hxc
+++ b/preload/scripts/characters/nene-dark.hxc
@@ -37,7 +37,7 @@ class NeneDarkCharacter extends NeneBaseCharacter
     stereoBG.color = 0xFF616785;
 
     abotTextureSwap = new TextureSwap();
-    abotTextureSwap.loadSwapImage(Paths.image('characters/abot/dark/abotSystem/spritemap1'));
+    abotTextureSwap.loadSwapImage(Assets.getPath(Paths.image('characters/abot/dark/abotSystem/spritemap1')));
     abot.shader = abotTextureSwap;
 
     vizAdjustColor = new AdjustColorShader();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6984
<!-- Briefly describe the issue(s) fixed. -->
## Description
Fixes Dark A-Bot not loading its dark textures by pointing it to the full file path using `Assets.getPath`
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
BEFORE:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7738e648-ad93-48a0-8fce-d3daa4ef0923" />

AFTER:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e02d5c52-70a1-4171-bd09-d32c44bdbed8" />
