### PR TITLE
[BUGFIX] Prevent gf `hairFall` anim on song retry

### DIFF
--- a/preload/scripts/stages/phillyTrain.hxc
+++ b/preload/scripts/stages/phillyTrain.hxc
@@ -152,7 +152,8 @@ class PhillyTrainStage extends Stage
 
   function trainReset():Void
   {
-    getGirlfriend().playAnimation('hairFall');
+    if (startedMoving) getGirlfriend().playAnimation('hairFall');
+
     getNamedProp('train').x = FlxG.width + 200;
 
     trainMoving = false;
@@ -168,6 +169,14 @@ class PhillyTrainStage extends Stage
   {
     super.onSongRetry(event);
     trainReset();
+
+    if (trainSound != null) trainSound.stop();
+
+    if (getGirlfriend() != null)
+    {
+      getGirlfriend().dance(true);
+      getGirlfriend().animation.finish();
+    }
   }
 
   function kill()

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -533,6 +533,8 @@ class PhillyTrainErectStage extends Stage
         getGirlfriend().playAnimation('hairFall');
     }
 
+    if (startedMoving) getGirlfriend().playAnimation('hairFall');
+
     trainMoving = false;
     trainCars = 8;
     trainFinishing = false;
@@ -543,6 +545,14 @@ class PhillyTrainErectStage extends Stage
   {
     super.onSongRetry(event);
     trainReset();
+
+    if (trainSound != null) trainSound.stop();
+
+    if (getGirlfriend() != null)
+    {
+      getGirlfriend().dance(true);
+      getGirlfriend().animation.finish();
+    }
   }
 
   public override function onSongEnd(event:CountdownScriptEvent):Void


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
FunkinCrew/Funkin#6749 - Girlfriend's hairFall animation plays after restarting in Philly Train stages.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes Gfs `hairFall` animation that would automatically play when you restart a song.

### Changes
-  Added a safety check in  `trainReset()` so `hairFall` only plays if `startedMoving` is true.
- `onSongRetry` Changes:
	- Added a `trainSound.stop()` call to prevent audio overlap on restart.
	- Added `getGirlfriend().dance(true)` to force a clean transition when restarting.
		- Added `.animation.finish()` for a safety check.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### BEFORE:
https://github.com/user-attachments/assets/505ce81d-2354-4818-b1e3-f210c34343d7
### AFTER:
> **NOTE**: This fix is applied to `PhillyTrainErect.hxc` also.

https://github.com/user-attachments/assets/71cb117d-7249-4d0c-ba6c-f8bead720527