### PR TITLE
[ENHANCEMENT] Add "Edit Note" option to Chart Editor note context menu

### DIFF
--- a/exclude/data/ui/chart-editor/context-menus/hold-note.xml
+++ b/exclude/data/ui/chart-editor/context-menus/hold-note.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu>
+	<menu-item id="contextmenuEdit" text="Edit Note" />
 	<menu-item id="contextmenuFlip" text="Flip Note" />
 	<menu-item id="contextmenuRemoveHold" text="Remove Hold" />
 	<menu-item id="contextmenuDelete" text="Delete Note" />

--- a/exclude/data/ui/chart-editor/context-menus/note.xml
+++ b/exclude/data/ui/chart-editor/context-menus/note.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu>
+	<menu-item id="contextmenuEdit" text="Edit Note" />
 	<menu-item id="contextmenuFlip" text="Flip Note" />
 	<menu-item id="contextmenuMirrorX" text="Mirror Note X Axis" shortcutText="Ctrl+Shift+M" />
 	<menu-item id="contextmenuAddHold" text="Add Hold" />


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/7010

<!-- Briefly describe the issue(s) fixed. -->
## Description
The softcoded values for my Edit Note PR.
Adds ``contextmenuEdit`` to both ``note.xml`` and ``hold-note.xml``