### PR TITLE
Better animation offsets for pixel characters

### DIFF
--- a/preload/data/characters/bf-pixel.json
+++ b/preload/data/characters/bf-pixel.json
@@ -21,19 +21,9 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singUP",
-      "prefix": "BF UP NOTE instance 10",
-      "offsets": [0, 0]
-    },
-    {
       "name": "singLEFT",
       "prefix": "BF LEFT NOTE instance 10",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singRIGHT",
-      "prefix": "BF RIGHT NOTE instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singDOWN",
@@ -41,19 +31,19 @@
       "offsets": [0, 0]
     },
     {
-      "name": "singUPmiss",
-      "prefix": "BF UP MISS instance 10",
+      "name": "singUP",
+      "prefix": "BF UP NOTE instance 10",
+      "offsets": [-1, 0]
+    },
+    {
+      "name": "singRIGHT",
+      "prefix": "BF RIGHT NOTE instance 10",
       "offsets": [0, 0]
     },
     {
       "name": "singLEFTmiss",
       "prefix": "BF LEFT MISS instance 10",
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singRIGHTmiss",
-      "prefix": "BF RIGHT MISS instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singDOWNmiss",
@@ -61,23 +51,33 @@
       "offsets": [0, 0]
     },
     {
+      "name": "singUPmiss",
+      "prefix": "BF UP MISS instance 10",
+      "offsets": [-1, 0]
+    },
+    {
+      "name": "singRIGHTmiss",
+      "prefix": "BF RIGHT MISS instance 10",
+      "offsets": [0, 0]
+    },
+    {
       "name": "firstDeath",
       "prefix": "BF Dies pixel",
       "assetPath": "characters/bfPixelsDEAD",
-      "offsets": [8.33, 0]
+      "offsets": [8, -1]
     },
     {
       "name": "deathLoop",
       "prefix": "Retry Loop",
       "assetPath": "characters/bfPixelsDEAD",
       "looped": true,
-      "offsets": [3.33, -2.08]
+      "offsets": [3, -3]
     },
     {
       "name": "deathConfirm",
       "prefix": "RETRY CONFIRM",
       "assetPath": "characters/bfPixelsDEAD",
-      "offsets": [3.33, -2.08]
+      "offsets": [3, -3]
     }
   ]
 }

--- a/preload/data/characters/gf-pixel.json
+++ b/preload/data/characters/gf-pixel.json
@@ -15,15 +15,7 @@
     {
       "name": "danceRight",
       "prefix": "GF IDLE",
-      "frameIndices": [
-        15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29
-      ],
-      "offsets": [0, 0]
-    },
-    {
-      "name": "singUP",
-      "prefix": "GF IDLE",
-      "frameIndices": [2],
+      "frameIndices": [15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29],
       "offsets": [0, 0]
     }
   ]

--- a/preload/data/characters/nene-pixel.json
+++ b/preload/data/characters/nene-pixel.json
@@ -23,25 +23,25 @@
     {
       "name": "raiseKnife",
       "prefix": "raise",
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     },
     {
       "name": "idleKnife",
       "prefix": "blink",
       "frameIndices": [6, 7],
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     },
     {
       "name": "idleKnifeBlink",
       "prefix": "blink",
       "frameIndices": [0, 1, 2, 3, 4, 5],
-      "offsets": [-19, 10]
+      "offsets": [-21, 10]
     },
     {
       "name": "lowerKnife",
       "prefix": "lower",
       "frameIndices": [0, 1, 2, 3, 4, 5],
-      "offsets": [0, 10]
+      "offsets": [-2, 10]
     }
   ]
 }

--- a/preload/data/characters/pico-pixel.json
+++ b/preload/data/characters/pico-pixel.json
@@ -37,7 +37,7 @@
     {
       "name": "singUP",
       "prefix": "up0",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singRIGHT",
@@ -57,7 +57,7 @@
     {
       "name": "singUPmiss",
       "prefix": "upmiss0",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     },
     {
       "name": "singRIGHTmiss",
@@ -67,18 +67,18 @@
     {
       "name": "firstDeath",
       "prefix": "firstDeath0",
-      "offsets": [0, 0]
+      "offsets": [-1, -1]
     },
     {
       "name": "deathLoop",
       "prefix": "deathLoop0",
       "looped": true,
-      "offsets": [0, 0]
+      "offsets": [-1, -1]
     },
     {
       "name": "deathConfirm",
       "prefix": "deathConfirm0",
-      "offsets": [0, 0]
+      "offsets": [-1, -1]
     }
   ]
 }

--- a/preload/data/characters/senpai-angry.json
+++ b/preload/data/characters/senpai-angry.json
@@ -12,28 +12,28 @@
   "animations": [
     {
       "name": "idle",
-      "prefix": "Angry Senpai Idle instance 1",
+      "prefix": "Angry Senpai Idle instance 10",
       "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "Angry Senpai LEFT NOTE instance 10",
-      "offsets": [6.6, 0]
+      "offsets": [4, 1]
     },
     {
       "name": "singDOWN",
       "prefix": "Angry Senpai DOWN NOTE instance 10",
-      "offsets": [2.33, 0]
+      "offsets": [1, 1]
     },
     {
       "name": "singUP",
       "prefix": "Angry Senpai UP NOTE instance 10",
-      "offsets": [0.83, 6.16]
+      "offsets": [1, 6]
     },
     {
       "name": "singRIGHT",
       "prefix": "Angry Senpai RIGHT NOTE instance 10",
-      "offsets": [0, 0]
+      "offsets": [-1, 0]
     }
   ]
 }

--- a/preload/data/characters/senpai.json
+++ b/preload/data/characters/senpai.json
@@ -18,17 +18,17 @@
     {
       "name": "singLEFT",
       "prefix": "SENPAI LEFT NOTE instance 10",
-      "offsets": [6.6, 0]
+      "offsets": [5, 0]
     },
     {
       "name": "singDOWN",
       "prefix": "SENPAI DOWN NOTE instance 10",
-      "offsets": [2.33, 0]
+      "offsets": [2, 0]
     },
     {
       "name": "singUP",
       "prefix": "SENPAI UP NOTE instance 10",
-      "offsets": [0.83, 6.16]
+      "offsets": [2, 6]
     },
     {
       "name": "singRIGHT",

--- a/preload/data/characters/spirit.json
+++ b/preload/data/characters/spirit.json
@@ -6,36 +6,38 @@
   "renderType": "packer",
   "isPixel": true,
   "scale": 6,
+  "offsets": [31, 40],
+  "cameraOffsets": [-31, -40],
   "animations": [
     {
       "name": "idle",
       "prefix": "idle spirit_",
       "frameIndices": [],
-      "offsets": [-36.66, -46.66]
+      "offsets": [0, 0]
     },
     {
       "name": "singLEFT",
       "prefix": "left_",
       "frameIndices": [],
-      "offsets": [-33.33, -46.66]
+      "offsets": [2, -2]
     },
     {
       "name": "singDOWN",
       "prefix": "spirit down_",
       "frameIndices": [],
-      "offsets": [28.33, 18.33]
+      "offsets": [65, 64]
     },
     {
       "name": "singUP",
       "prefix": "up_",
       "frameIndices": [],
-      "offsets": [-36.66, -40.0]
+      "offsets": [0, 9]
     },
     {
       "name": "singRIGHT",
       "prefix": "right_",
       "frameIndices": [],
-      "offsets": [-36.66, -46.66]
+      "offsets": [-3, 1]
     }
   ]
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
None

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
This pull request makes several improvements to the pixel character offsets:
- **BF (Pixel)**: Better aligned offsets for `singLEFT` and `singLEFTmiss`, `singUP` and `singUPmiss`, and the death animation. I also organized his `.json` file to match the other characters'.
- **GF (Pixel)**: I removed `singUP`, an animation that was unused.
- **Pico (Pixel)**: Better aligned offsets for `singUP` and `singUPmiss`, and the death animation.
- **Nene (Pixel)**: Better aligned offsets for his four knife-raising animations.
- **Senpai**: Better aligned offsets for `singLEFT`, `singDOWN`, and `singUP`.
- **Senpai (Angry)**: Better aligned offsets for his four sing animations.
- **Spirit**: Better aligned offsets for his four sing animations. For some reason, Spirit's offsets were originally modified in each of his animations to center him on the game camera, instead of in his global offsets. I changed this to keep his idle at `[0, 0]`. While doing this, I made sure that his camera and position in his stage were as close to the original as possible.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
To see the changes, you can watch the video I made several months ago for my other PRs (you can skip to the parts of the video where the pixelated characters are shown): https://youtu.be/KMfvUnbRmwQ

The only thing that changes in this video compared to the current PR is a small difference in the offsets of Pico's (Pixel) death animation.

https://github.com/user-attachments/assets/04d62226-21d4-4c06-a0a5-766d6a4ae5e5

