### PR TITLE
[ENHANCEMENT] Added an option to disable start cutscenes on freeplay songs

### DIFF
--- a/preload/scripts/songs/roses-pico.hxc
+++ b/preload/scripts/songs/roses-pico.hxc
@@ -27,6 +27,9 @@ class RosesPicoMixSong extends Song
     // Skip the cutscene if we're playtesting in the Chart Editor.
     if (PlayState.instance.isChartingMode && !hasPlayedCutscene) hasPlayedCutscene = true;
 
+    // Skip the cutscene if we've disabled cutscenes in freeplay from the options menu.
+    if (!Preferences.freeplayCutscenes && !hasPlayedCutscene) hasPlayedCutscene = true;
+
     if (!hasPlayedCutscene)
     {
       trace('Pausing countdown to play cutscene.');

--- a/preload/scripts/songs/senpai-pico.hxc
+++ b/preload/scripts/songs/senpai-pico.hxc
@@ -28,6 +28,9 @@ class SenpaiPicoMixSong extends Song
     // Skip the cutscene if we're playtesting in the Chart Editor.
     if (PlayState.instance.isChartingMode && !hasPlayedCutscene) hasPlayedCutscene = true;
 
+    // Skip the cutscene if we've disabled cutscenes in freeplay from the options menu.
+    if (!Preferences.freeplayCutscenes && !hasPlayedCutscene) hasPlayedCutscene = true;
+
     if (!hasPlayedCutscene)
     {
       trace('Pausing countdown to play cutscene.');

--- a/preload/scripts/songs/stress-pico.hxc
+++ b/preload/scripts/songs/stress-pico.hxc
@@ -34,6 +34,11 @@ class StressPicoMixSong extends Song
     // Skip the cutscene if we're playtesting in the Chart Editor.
     if (PlayState.instance.isChartingMode && !hasPlayedCutscene) hasPlayedCutscene = true;
 
+    // Skip the cutscene if we've disabled cutscenes in freeplay from the options menu.
+    if (!Preferences.freeplayCutscenes && !hasPlayedCutscene) {
+      hasPlayedCutscene = true;
+    }
+
     if (!hasPlayedCutscene)
     {
       trace('Pausing countdown to play a video cutscene (`stress`)');

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -65,7 +65,7 @@ class PhillyTrainErectStage extends Stage
 
     if (!hasPlayedInGameCutscene
       && PlayState.instance.currentStage.getBoyfriend()?.characterId == 'pico-playable'
-      && !PlayState.instance.isChartingMode)
+      && !PlayState.instance.isChartingMode && Preferences.freeplayCutscenes)
     {
       trace('Pausing countdown to play in game cutscene');
 

--- a/preload/scripts/stages/sserafim.hxc
+++ b/preload/scripts/stages/sserafim.hxc
@@ -573,11 +573,22 @@ class SserafimStage extends Stage
   {
     super.onCountdownStart(event);
 
+    // Skip the cutscene if we're playtesting in the Chart Editor.
     if (PlayState.instance.isChartingMode && !hasPlayedCutscene)
     {
       hasPlayedCutscene = true;
       cutsceneSkipped = true;
       playCutsceneFromRestart();
+    }
+
+    // Skip the cutscene if we've disabled cutscenes in freeplay from the options menu.
+    if (!Preferences.freeplayCutscenes && !hasPlayedCutscene)
+    {
+      if (!PlayStatePlaylist.isStoryMode){
+        hasPlayedCutscene = true;
+        cutsceneSkipped = true;
+        playCutsceneFromRestart();
+      }
     }
 
     if (!hasPlayedCutscene)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
# This change depends on my funkin repo PR here:
**[PR #7081](https://github.com/FunkinCrew/Funkin/pull/7081)**

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR is adding an option that disables start cutscenes on freeplay song, like: Pico, Philly, Blammed pico mixes, Spaghetti, Stress Pico Mix, Senpai and Roses pico mixes.

<!-- Include any relevant screenshots or videos. -->
## Screenshot
<img width="1592" height="880" alt="fenasal funkin" src="https://github.com/user-attachments/assets/e5670b66-8a37-4e54-90fd-105715c6385e" />