### PR TITLE
Fix rimlight shader applying incorrectly to A-Bot (Again)

### DIFF
--- a/preload/scripts/characters/nene-tankmen.hxc
+++ b/preload/scripts/characters/nene-tankmen.hxc
@@ -9,7 +9,6 @@ class NeneTankmenCharacter extends NeneBaseCharacter
     super('nene-tankmen');
   }
 
-  var adjustColor:AdjustColorShader;
   var vizAdjustColor:AdjustColorShader;
   var comboHeart:FunkinSprite;
 
@@ -17,32 +16,8 @@ class NeneTankmenCharacter extends NeneBaseCharacter
   {
     super.onCreate(event);
 
-    adjustColor = new AdjustColorShader();
-
-    adjustColor.hue = -40;
-    adjustColor.saturation = -20;
-    adjustColor.brightness = -40;
-    adjustColor.contrast = -25;
-
-    vizAdjustColor = new AdjustColorShader();
-
-    vizAdjustColor.brightness = -12;
-    vizAdjustColor.hue = -30;
-    vizAdjustColor.contrast = 0;
-    vizAdjustColor.saturation = -10;
-
-    stereoBG.shader = adjustColor;
-    pupil.shader = adjustColor;
-    abot.shader = adjustColor;
-
-    for (spr in abotViz.members)
-    {
-      spr.shader = vizAdjustColor;
-    }
-
     comboHeart = FunkinSprite.createSparrow(0, 0, "characters/Nene_comboHeart");
     comboHeart.animation.addByPrefix("idle", "hearts aflutter", 24, false);
-    comboHeart.shader = adjustColor;
     comboHeart.zIndex = this.zIndex + 1;
     comboHeart.visible = false;
 
@@ -78,5 +53,32 @@ class NeneTankmenCharacter extends NeneBaseCharacter
   {
     // Don't synchronize shaders
     // This prevents the rimlight shader from being applied to A-Bot
+
+    //nu uh
+    adjustColor = new AdjustColorShader();
+
+    adjustColor.hue = -40;
+    adjustColor.saturation = -20;
+    adjustColor.brightness = -40;
+    adjustColor.contrast = -25;
+
+    vizAdjustColor = new AdjustColorShader();
+
+    vizAdjustColor.brightness = -12;
+    vizAdjustColor.hue = -30;
+    vizAdjustColor.contrast = 0;
+    vizAdjustColor.saturation = -10;
+
+    stereoBG.shader = adjustColor;
+    pupil.shader = adjustColor;
+    abot.shader = adjustColor;
+
+    for (spr in abotViz.members)
+    {
+      spr.shader = vizAdjustColor;
+    }
+
+    comboHeart.shader = adjustColor;
+
   }
 }

--- a/preload/scripts/characters/nene.hxc
+++ b/preload/scripts/characters/nene.hxc
@@ -6,6 +6,9 @@ import flixel.FlxG;
 import funkin.graphics.FunkinSprite;
 import funkin.audio.visualize.ABotVis;
 
+import funkin.graphics.shaders.AdjustColorShader;
+import funkin.graphics.shaders.DropShadowShader;
+
 /**
  * One of two states that the A-Bot's pupils can be in.
  */
@@ -402,26 +405,41 @@ class NeneBaseCharacter extends AnimateAtlasCharacter
     hasSetupAbot = true;
   }
 
-  var currentShader:FlxRuntimeShader = null;
+var currentShader = null;
+var adjustColor:AdjustColorShader;
 
-  function synchronizeShader():Void
-  {
-    if (currentShader == this.shader) return;
+function synchronizeShader():Void {
+		if (currentShader == this.shader)
+			return;
 
-    currentShader = this.shader;
+		currentShader = this.shader;
 
-    abot.shader = currentShader;
-    abotViz.shader = currentShader;
-    stereoBG.shader = currentShader;
-    eyeWhites.shader = currentShader;
+		if (Std.isOfType(this.shader, DropShadowShader)) {
+			adjustColor = new AdjustColorShader();
+			adjustColor.brightness = this.shader.baseBrightness;
+			adjustColor.hue = this.shader.baseHue;
+			adjustColor.contrast = this.shader.baseContrast;
+			adjustColor.saturation = this.shader.baseSaturation;
+			abot.shader = adjustColor;
 
-    for (member in abotViz.members)
-    {
-      member.shader = currentShader;
-    }
+			stereoBG.shader = adjustColor;
+			eyeWhites.shader = adjustColor;
+			for (member in abotViz.members) {
+				member.shader = adjustColor;
+			}
+		} else {
+			abot.shader = this.shader;
 
-    trace("Synchronized shader between children!");
-  }
+			stereoBG.shader = this.shader;
+			eyeWhites.shader = this.shader;
+			for (member in abotViz.members) {
+				member.shader = this.shader;
+			}
+		}
+
+		trace("Synchronized shader between children!");
+	
+}
 
   public override function onSongStart(event:ScriptEvent):Void
   {


### PR DESCRIPTION
Fixes the rim light shader not being added properly to A-Bot for Nene, Nene and Nene Christmas, while keeping the shader the same for Nene Tankman, now functional for 0.8.3

A recreation of this PR that I made before, and closed because I thought the bug got fixed (It did not :P) https://github.com/FunkinCrew/funkin.assets/pull/309

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

https://github.com/FunkinCrew/Funkin/issues/6505

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/05e72c13-b1f7-441d-bbbc-6816a5b14694

The video shows regular Nene functioning normally with the shader on the Tankman Erect stage, and then switching to Nene Tankmen to show how the regular shader adjustments for this week aren't broken by this PR