### PR TITLE
Disable Winter Horrorland cutscene in Freeplay

### DIFF
--- a/preload/scripts/songs/winter-horrorland.hxc
+++ b/preload/scripts/songs/winter-horrorland.hxc
@@ -7,6 +7,7 @@ import funkin.Paths;
 import funkin.audio.FunkinSound;
 import funkin.play.song.Song;
 import funkin.play.PlayState;
+import funkin.play.PlayStatePlaylist;
 import funkin.util.HapticUtil;
 
 class WinterHorrorlandSong extends Song
@@ -26,6 +27,8 @@ class WinterHorrorlandSong extends Song
   override public function onCountdownStart(event:CountdownScriptEvent):Void
   {
     super.onCountdownStart(event);
+
+    if (!PlayStatePlaylist.isStoryMode) hasPlayedCutscene = true;
 
     if (!hasPlayedCutscene)
     {


### PR DESCRIPTION
## Linked Issues
Hungrec.
<!-- Briefly describe the issue(s) fixed. -->
## Description
Disallows the cutscene for Winter Horrorland to play when entering the song through Freeplay.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e0fbf3bd-51a3-4d9e-a582-707e7560c079

