### PR TITLE
[BUGFIX] Lower Results Screen camera transition for Week 6 Erect stage

### DIFF
--- a/preload/scripts/stages/schoolErect.hxc
+++ b/preload/scripts/stages/schoolErect.hxc
@@ -110,4 +110,16 @@ class SchoolErectStage extends Stage
       default:
     }
   }
+  
+  function onSongEnd(event:ScriptEvent):Void
+  {
+    super.onSongEnd(event);
+    if (event.eventcanceled)
+    {
+      // onSongEnd event was cancelled by the gameplay module.
+      return;
+    }
+    // Move the camera transition less to stop the tree cut offs from showing
+    FlxG.camera.targetOffset.y += 125;
+  }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/4917

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR forces the camera movement when a song ends to not move as far up as usual for School (Date) [Erect] to prevent the cut off parts of the tree assets from being shown

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/b0a41082-8629-43a7-80b1-972e65914ac8

