### PR TITLE
Remove Doubled 'singUP' animation

### DIFF
--- a/preload/data/characters/bf-holding-gf.json
+++ b/preload/data/characters/bf-holding-gf.json
@@ -9,12 +9,6 @@
   },
   "animations": [
     {
-      "name": "singUP",
-      "prefix": "BF Dead with GF Loop",
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [0, 0]
-    },
-    {
       "name": "firstDeath",
       "prefix": "BF Dies with GF",
       "assetPath": "characters/bfHoldingGF-DEAD",


### PR DESCRIPTION
Removed Doubled  'singUP' animation from bf-holding-gf.json

Removed the duplicate singUP animation at the beginning of the animations list. It was incorrectly using the BF Dead with GF Loop prefix and the bfHoldingGF-DEAD asset path.

removed
  ```
{
      "name": "singUP",
      "prefix": "BF Dead with GF Loop",
      "assetPath": "characters/bfHoldingGF-DEAD",
      "offsets": [0, 0]
    },
```

