### PR TITLE
[CHORE] Remove duplicate singUP in bf-holding-gf

### DIFF
--- a/preload/data/characters/bf-holding-gf.json
+++ b/preload/data/characters/bf-holding-gf.json
@@ -9,12 +9,6 @@
   },
   "animations": [
     {
-      "name": "singUP",
-      "prefix": "BF Dead with GF Loop",
-      "assetPath": "characters/bfHoldingGF-DEAD",
-      "offsets": [0, 0]
-    },
-    {
       "name": "firstDeath",
       "prefix": "BF Dies with GF",
       "assetPath": "characters/bfHoldingGF-DEAD",


### PR DESCRIPTION
<!-- Briefly describe the issue(s) fixed. -->
## Description
Was looking through some character jsons and found that bf-holding-gf had a weird extra singUp animation with it's Gameover Loop as it's prefix, so I took it out back to save the game B)

<!-- Include any relevant screenshots or videos. -->
## Screenshot
<img width="532" height="181" alt="Screenshot 2026-03-13 131940" src="https://github.com/user-attachments/assets/751b4bf4-8be2-40de-8841-e58dbb32b985" />
