### PR TITLE
[QOL] Relabel SPAGHETTI's capsule text to match Story Mode

### DIFF
--- a/preload/data/levels/sserafim.json
+++ b/preload/data/levels/sserafim.json
@@ -1,6 +1,9 @@
 {
   "version": "1.0.0",
   "name": "LE SSERAFIM",
+  "capsule": {
+    "name": "SP. COLLAB 1"
+  },
   "titleAsset": "storymenu/titles/sserafim",
   "props": [
     {


### PR DESCRIPTION
## Associated Funkin PR

https://github.com/FunkinCrew/Funkin/pull/7149

## Linked Issues

<img width="32" height="33" alt="image" src="https://github.com/user-attachments/assets/a5a9d579-9526-4d3c-8451-db63002f6289" />

## Description

Relabels SPAGHETTI's capsule text from just 'SSERAFIM' to 'SP. COLLAB 1' to match with Story Mode.

## Screenshots/Videos

<img width="965" height="356" alt="image" src="https://github.com/user-attachments/assets/11a3b15e-dd98-4da5-9c57-6f6c03ccdd65" />

