### PR TITLE
[ENHANCEMENT] Adjust note splashes to match scale from FLA

### DIFF
--- a/preload/data/notestyles/funkin.json
+++ b/preload/data/notestyles/funkin.json
@@ -44,8 +44,9 @@
     },
     "noteSplash": {
       "assetPath": "shared:noteSplashes",
+      "scale": 0.7,
       "alpha": 0.8,
-      "offsets": [25, -5],
+      "offsets": [0, -42],
       "data": {
         "enabled": true,
         "leftSplashes": [


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
None

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
None

<!-- Briefly describe the issue(s) fixed. -->
## Description
Correct the scaling of "funkin" notestyle notesplashes from 1.0 to 0.7 to match with the splashes from the public FLA

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

In Public FLA:

![Animate_h0xvuG1LPb](https://github.com/user-attachments/assets/5ac024e3-e87b-4b2d-afff-65293e6aa0ca)


After:

![Funkin_lbBydDm5QH](https://github.com/user-attachments/assets/3aa50d32-336c-4355-9d2e-6e39187cbb1e)


Before:

![Funkin_i82yXYFwCe](https://github.com/user-attachments/assets/bad8aa59-aeac-438f-a191-ffb2f86d7721)
