### PR TITLE
[BUGFIX] Fix Darnell & Pico Blazin's danceEvery getting reset

### DIFF
--- a/preload/scripts/characters/darnell-blazin.hxc
+++ b/preload/scripts/characters/darnell-blazin.hxc
@@ -17,6 +17,12 @@ class DarnellBlazinCharacter extends AnimateAtlasCharacter
     this.playAnimation('idle', true, false);
   }
 
+  function resetCharacter(resetCamera:Bool = true):Void
+  {
+    super.resetCharacter(resetCamera);
+    this.danceEvery = 0;
+  }
+  
   var cantUppercut = false;
 
   function onNoteHit(event:HitNoteScriptEvent)

--- a/preload/scripts/characters/pico-blazin.hxc
+++ b/preload/scripts/characters/pico-blazin.hxc
@@ -30,6 +30,12 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
     PauseSubState.musicSuffix = '-pico';
   }
 
+  function resetCharacter(resetCamera:Bool = true):Void
+  {
+    super.resetCharacter(resetCamera);
+    this.danceEvery = 0;
+  }
+  
   var cantUppercut = false;
 
   function onNoteHit(event:HitNoteScriptEvent)


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7163

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR stops Darnell & Pico Blazin's danceEvery count from getting reset back to 1, causing their animations to go to idle sometimes and breaking the final uppercut

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE:

https://github.com/user-attachments/assets/96d7a7e7-1f1e-4388-9945-63a9f896fda7

AFTER:

https://github.com/user-attachments/assets/8a55fc89-5717-4303-8ace-e6c0f51401e6


