### PR TITLE
[BUGFIX] Fix Spirit's trail being FPS-dependent

### DIFF
--- a/preload/scripts/characters/spirit.hxc
+++ b/preload/scripts/characters/spirit.hxc
@@ -15,7 +15,7 @@ class SpiritCharacter extends PackerCharacter
     super.onCreate(event);
 
     // Weird workaround because `this` is a PolymodScriptClass and not a ScriptedPackerCharacter.
-    var evilTrail = new FunkTrail(this.superClass, null, 4, 24, 0.3, 0.069);
+    var evilTrail = new FunkTrail(this.superClass, null, 4, 0.4, 0.3, 0.069);
 
     // Go behind Spirit.
     evilTrail.zIndex = 190;


### PR DESCRIPTION
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/7179

## Description
Spirits trail was practically non-existent when on higher framerate. This PR fixes that.
