### PR TITLE
[BUGFIX] Pause & cancel lightning tweens during pause / game over

### DIFF
--- a/preload/scripts/stages/spookyMansionErect.hxc
+++ b/preload/scripts/stages/spookyMansionErect.hxc
@@ -5,12 +5,13 @@ import flixel.tweens.FlxEase;
 import flixel.tweens.FlxTween;
 import funkin.util.FlxTweenUtil;
 import funkin.util.HapticUtil;
-import flixel.util.FlxTimer;
 import funkin.play.character.BaseCharacter;
 import funkin.data.character.CharacterDataParser;
 import funkin.play.character.CharacterType;
 import funkin.graphics.shaders.RuntimeRainShader;
 import funkin.FunkinMemory;
+import funkin.util.FlxTweenUtil;
+import funkin.util.Sequence;
 
 class SpookyMansionErectStage extends Stage
 {
@@ -24,6 +25,9 @@ class SpookyMansionErectStage extends Stage
 
   var lightningStrikeBeat:Int = 0;
   var lightningStrikeOffset:Int = 8;
+
+  var lightningSequence:Sequence;
+  var lightningSequenceData:Array<SequenceData>;
 
   override function onCreate(event:ScriptEvent):Void
   {
@@ -43,6 +47,36 @@ class SpookyMansionErectStage extends Stage
     // Precache the thunder sounds.
     for (snd in ["thunder_1", "thunder_2"])
       FunkinMemory.cacheSound(Paths.sound(snd));
+
+    lightningSequenceData = [
+      {
+        time: 0.06,
+        callback: () ->
+        {
+          getNamedProp('bgLight').alpha = 0;
+          getNamedProp('stairsLight').alpha = 0;
+          getBoyfriend()?.alpha = 1;
+          getDad()?.alpha = 1;
+          getGirlfriend()?.alpha = 1;
+        }
+      },
+      {
+        time: 0.12,
+        callback: () ->
+        {
+          getNamedProp('bgLight').alpha = 1;
+          getNamedProp('stairsLight').alpha = 1;
+          getBoyfriend()?.alpha = 0;
+          getDad()?.alpha = 0;
+          getGirlfriend()?.alpha = 0;
+          FlxTween.tween(getNamedProp('bgLight'), {alpha: 0}, 1.5);
+          FlxTween.tween(getNamedProp('stairsLight'), {alpha: 0}, 1.5);
+          if (getBoyfriend() != null) FlxTween.tween(getBoyfriend(), {alpha: 1}, 1.5);
+          if (getDad() != null) FlxTween.tween(getDad(), {alpha: 1}, 1.5);
+          if (getGirlfriend() != null) FlxTween.tween(getGirlfriend(), {alpha: 1}, 1.5);
+        }
+      }
+    ];    
   }
 
   function onBranchFrame(name, frameNum, frameIndex)
@@ -79,28 +113,7 @@ class SpookyMansionErectStage extends Stage
     getDad().alpha = 0;
     getGirlfriend().alpha = 0;
 
-    new FlxTimer().start(0.06, function(_)
-    {
-      getNamedProp('bgLight').alpha = 0;
-      getNamedProp('stairsLight').alpha = 0;
-      getBoyfriend()?.alpha ??= 1;
-      getDad().alpha = 1;
-      getGirlfriend().alpha = 1;
-    });
-
-    new FlxTimer().start(0.12, function(_)
-    {
-      getNamedProp('bgLight').alpha = 1;
-      getNamedProp('stairsLight').alpha = 1;
-      getBoyfriend()?.alpha ??= 0;
-      getDad().alpha = 0;
-      getGirlfriend().alpha = 0;
-      FlxTween.tween(getNamedProp('bgLight'), {alpha: 0}, 1.5);
-      FlxTween.tween(getNamedProp('stairsLight'), {alpha: 0}, 1.5);
-      if (getBoyfriend() != null) FlxTween.tween(getBoyfriend(), {alpha: 1}, 1.5);
-      FlxTween.tween(getDad(), {alpha: 1}, 1.5);
-      FlxTween.tween(getGirlfriend(), {alpha: 1}, 1.5);
-    });
+    lightningSequence = new Sequence(lightningSequenceData);
 
     lightningStrikeBeat = beat;
     lightningStrikeOffset = FlxG.random.int(8, 24);
@@ -182,6 +195,28 @@ class SpookyMansionErectStage extends Stage
     }
   }
 
+  override function onPause(event:PauseScriptEvent)
+  {
+    super.onPause(event);
+    if (lightningSequence != null) lightningSequence.running = false;
+    FlxTweenUtil.pauseTweensOf(getNamedProp('bgLight'), ['alpha']);
+    FlxTweenUtil.pauseTweensOf(getNamedProp('stairsLight'), ['alpha']);
+    if (getBoyfriend() != null) FlxTweenUtil.pauseTweensOf(getBoyfriend(), ['alpha']);
+    if (getDad() != null) FlxTweenUtil.pauseTweensOf(getDad(), ['alpha']);
+    if (getGirlfriend() != null) FlxTweenUtil.pauseTweensOf(getGirlfriend(), ['alpha']);
+  }
+
+  override function onResume(event:ScriptEvent)
+  {
+    super.onResume(event);
+    if (lightningSequence != null) lightningSequence.running = true;
+    FlxTweenUtil.resumeTweensOf(getNamedProp('bgLight'), ['alpha']);
+    FlxTweenUtil.resumeTweensOf(getNamedProp('stairsLight'), ['alpha']);
+    if (getBoyfriend() != null) FlxTweenUtil.resumeTweensOf(getBoyfriend(), ['alpha']);
+    if (getDad() != null) FlxTweenUtil.resumeTweensOf(getDad(), ['alpha']);
+    if (getGirlfriend() != null) FlxTweenUtil.resumeTweensOf(getGirlfriend(), ['alpha']);
+  }
+
   function onSongRetry(event:ScriptEvent)
   {
     super.onSongRetry(event);
@@ -204,7 +239,17 @@ class SpookyMansionErectStage extends Stage
   {
     super.onGameOver(event);
 
-    // Make sure the player character is visible when dying on the same frame as the lightning strikes.
-    getBoyfriend().alpha = 1;
+    // Stop the lightning sequence from continuing.
+    if (lightningSequence != null) lightningSequence.destroy();
+
+    // Make sure all alpha values get reset when dying.
+    getNamedProp('bgLight').alpha = 0;
+    getNamedProp('stairsLight').alpha = 0;
+    if (getBoyfriend() != null) FlxTween.cancelTweensOf(getBoyfriend(), ['alpha']);
+    if (getDad() != null) FlxTween.cancelTweensOf(getDad(), ['alpha']);
+    if (getGirlfriend() != null)  FlxTween.cancelTweensOf(getGirlfriend(), ['alpha']);
+    getBoyfriend()?.alpha = 1;
+    getDad()?.alpha = 1;
+    getGirlfriend()?.alpha = 1;
   }
 }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7177

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR :
- Switches out the FlxTimers the lightning currently uses for a Sequence, allowing the lightning effects to pause when pausing the game.
- Pauses all lightning tweens when pausing the game
- Cancel the tweens when getting a game over to prevent BF from fading in

yes i know this code is very scary i'm sorry

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/e87babbe-734d-4e3d-b523-7e9581901935

