### PR TITLE
Adjust the offsets for GF on the Week 1 Erect Stage

### DIFF
--- a/preload/data/stages/mainStageErect.json
+++ b/preload/data/stages/mainStageErect.json
@@ -143,7 +143,7 @@
       "position": [40, 885],
       "cameraOffsets": [270, -100]
     },
-    "gf": { "zIndex": 100, "cameraOffsets": [0, 0], "position": [501.5, 815] }
+    "gf": { "zIndex": 100, "cameraOffsets": [0, -25], "position": [501.5, 840] }
   },
   "name": "Main Stage [Erect]",
   "directory": "week1"


### PR DESCRIPTION
Sorry Hundrec

Fixes the offset for GF on the week 1 erect stage to not be overlaying the background

BEFORE

<img width="344" height="317" alt="image" src="https://github.com/user-attachments/assets/fdeb0f34-8ae6-436c-b01a-9752fe605ead" />


AFTER

<img width="433" height="386" alt="image" src="https://github.com/user-attachments/assets/7a2d2e26-1c63-4cce-a88b-115d72098bb1" />
