### PR TITLE
Make Nene Dark A-Bot load images the old way again

### DIFF
--- a/preload/scripts/characters/nene-dark.hxc
+++ b/preload/scripts/characters/nene-dark.hxc
@@ -40,7 +40,7 @@ class NeneDarkCharacter extends NeneBaseCharacter
     stereoBG.color = 0xFF616785;
 
     abotTextureSwap = new TextureSwap();
-    abotTextureSwap.loadSwapImage(Assets.getPath(Paths.image('characters/abot/dark/abotSystem/spritemap1')));
+    abotTextureSwap.loadSwapImage(Paths.image('characters/abot/dark/abotSystem/spritemap1'));
     abot.shader = abotTextureSwap;
 
     vizAdjustColor = new AdjustColorShader();


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/7194
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
N/A
<!-- Briefly describe the issue(s) fixed. -->
## Description

Reverts a change done to get the full path for the texture since `TextureSwap` uses funkin.Assets to get the texture now.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
Refer to the associated PR for the screenshot.