### PR TITLE
[FIX] Fix unused BF miss animations in SPAGHETTI by correcting the switch case separator.

### DIFF
--- a/preload/scripts/characters/sserafim-sakura.hxc
+++ b/preload/scripts/characters/sserafim-sakura.hxc
@@ -98,7 +98,7 @@ class SserafimSakuraCharacter extends MultiAnimateAtlasCharacter
       case "sakura-joint": // joint animations, sakura and bf sing
         this.playSingAnimation(event.note.noteData.getDirection(), true, 'joint');
         return;
-      case "sakura-bf1" || "sakura-bf2": // bf animations, only bf sings
+      case "sakura-bf1" | "sakura-bf2": // bf animations, only bf sings
         this.playSingAnimation(event.note.noteData.getDirection(), true, 'bf2');
         return;
     }


### PR DESCRIPTION
## Description
This PR fixes the unused switch case in SPAGHETTI during bf singing because it used `||` instead of `|` for separation.

> [!IMPORTANT]
> Requires this PR to work: https://github.com/FunkinCrew/polymod/pull/381

## Screenshots/Videos

## Before

https://github.com/user-attachments/assets/c77ae9d4-3ce0-4fd3-9889-8997801d4601

## After PR

https://github.com/user-attachments/assets/0b62acba-10dd-4ed3-84eb-c1b5399a7870

