### PR TITLE
[BUGFIX] Fix Pico (Pixel)'s deathLoop anim cutting off firstDeath anim

### DIFF
--- a/preload/scripts/characters/pico-pixel.hxc
+++ b/preload/scripts/characters/pico-pixel.hxc
@@ -67,13 +67,18 @@ class PicoPixelCharacter extends SparrowCharacter
   {
     super.onAnimationFrame(name, frameNumber, frameIndex);
 
-    if (name == "firstDeath" && frameNumber == 36 - 1)
+    if (name == "firstDeath")
     {
-      GameOverSubState.instance.startDeathMusic(1.0, false);
-      // force the deathloop to play in here, since we are starting the music early it
-      // doesn't check this in gameover substate !
-      // also no animation suffix 🤔
-      GameOverSubState.instance.boyfriend.playAnimation('deathLoop');
+      if (frameNumber == 36 - 1)
+      {
+        GameOverSubState.instance.startDeathMusic(1.0, false);
+      }
+      else if (frameNumber == this.animation.curAnim.numFrames - 1)
+      {
+        // force the deathloop to play before the anim fully ends
+        // this stops the GameOverSubState from running the original code while still keeping the original look
+        GameOverSubState.instance.boyfriend.playAnimation('deathLoop');  
+      }
     }
 
     if (!HapticUtil.hapticsAvailable) return;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR retimes when Pico (Pixel)'s deathLoop anim plays to prevent it from cutting off the firstDeath anim and looking janky (which I had accidentally broken before whoops)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE:

https://github.com/user-attachments/assets/77967bd3-9de9-4579-83e7-0793dfc40507

AFTER:


https://github.com/user-attachments/assets/7c27ddf9-bed3-43fd-b063-16910a353ea0

