### PR TITLE
[BUGFIX] Prevent Doppleganger Pico vocals from starting if he's dead

### DIFF
--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -541,6 +541,13 @@ class PhillyTrainErectStage extends Stage
     startedMoving = false;
   }
 
+  override function onSongStart(event:ScriptEvent)
+  {
+    super.onSongStart(event);
+
+    if (explode && playerShoots) PlayState.instance.vocals.opponentVolume = 0;
+  }
+
   override function onSongRetry(event:ScriptEvent)
   {
     super.onSongRetry(event);


### PR DESCRIPTION
## Linked Issues
Didn't find any ¯\_(ツ)_/¯

## Description
Prevents Doppleganger Pico's vocals from starting abruptly for a millisecond when he 'sings' if the game considers him dead.

## Screenshots/Videos
https://github.com/user-attachments/assets/51b7f5f4-5663-4b59-9bce-f0d50b5a7d85

https://github.com/user-attachments/assets/3f8cd47f-1235-4b47-9685-97e8180bdca3

