### PR TITLE
[ENHANCEMENT/Modding] Move SongEvents to scripts.

### DIFF
--- a/preload/scripts/events/FocusCameraSongEvent.hxc
+++ b/preload/scripts/events/FocusCameraSongEvent.hxc
@@ -1,0 +1,220 @@
+package funkin.play.event;
+
+import flixel.tweens.FlxEase;
+import funkin.Conductor;
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+import funkin.util.ReflectUtil;
+
+/**
+ * This class handles song events which change the camera focus.
+ * This lets you center the camera on a character, on a stage prop, or a specific position on the screen,
+ * as well as apply relative offsets, and even determine the speed and manner with which
+ * the camera moves into place.
+ *
+ * Example: Focus on Boyfriend:
+ * ```
+ * {
+ *   "e": "FocusCamera",
+ * 	 "v": {
+ * 	 	 "char": 0,
+ *   }
+ * }
+ * ```
+ *
+ * Example: Focus on 10px above Girlfriend:
+ * ```
+ * {
+ *   "e": "FocusCamera",
+ * 	 "v": {
+ * 	   "char": 2,
+ * 	   "y": -10,
+ *   }
+ * }
+ * ```
+ *
+ * Example: Focus on (100, 100):
+ * ```
+ * {
+ *   "e": "FocusCamera",
+ *   "v": {
+ *     "char": -1,
+ *     "x": 100,
+ *     "y": 100,
+ *   }
+ * }
+ * ```
+ */
+class FocusCameraSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('FocusCamera', {
+      processOldEvents: true
+    });
+  }
+
+  static final DEFAULT_X_POSITION:Float = 0.0;
+  static final DEFAULT_Y_POSITION:Float = 0.0;
+  static final DEFAULT_DURATION:Float = 4.0;
+  static final DEFAULT_CAMERA_EASE:String = 'CLASSIC';
+  static final DEFAULT_TARGET:Int = 0; // Boyfriend
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    // Does nothing if we are minimal mode.
+    if (PlayState.instance.isMinimalMode) return;
+
+    var posX:Null<Float> = data.getFloat('x');
+    if (posX == null) posX = DEFAULT_X_POSITION;
+    var posY:Null<Float> = data.getFloat('y');
+    if (posY == null) posY = DEFAULT_Y_POSITION;
+
+    var char:Null<Int> = data.getInt('char');
+
+    if (char == null) char = data.value;
+    if (char == null) char = DEFAULT_TARGET;
+
+    var duration:Null<Float> = data.getFloat('duration');
+    if (duration == null) duration = DEFAULT_DURATION;
+    var ease:Null<String> = data.getString('ease');
+    if (ease == null) ease = DEFAULT_CAMERA_EASE; // No linear in defaults lol
+
+    var easeDir:String = data.getString('easeDir') ?? SongEvent.DEFAULT_EASE_DIR;
+    if (SongEvent.EASE_TYPE_DIR_REGEX.match(ease) || ease == "linear") easeDir = "";
+
+    var currentStage = PlayState.instance.currentStage;
+
+    // Get target position based on char.
+    var targetX:Float = posX;
+    var targetY:Float = posY;
+
+    switch (char)
+    {
+      case -1: // Position ("focus" on origin)
+        trace('Focusing camera on static position.');
+
+      case 0: // Boyfriend (focus on player)
+        if (currentStage.getBoyfriend() == null)
+        {
+          trace('No BF to focus on.');
+          return;
+        }
+        trace('Focusing camera on player.');
+        var bfPoint = currentStage.getBoyfriend().cameraFocusPoint;
+        targetX += bfPoint.x;
+        targetY += bfPoint.y;
+
+      case 1: // Dad (focus on opponent)
+        if (currentStage.getDad() == null)
+        {
+          trace('No dad to focus on.');
+          return;
+        }
+        trace('Focusing camera on opponent.');
+        var dadPoint = currentStage.getDad().cameraFocusPoint;
+        targetX += dadPoint.x;
+        targetY += dadPoint.y;
+
+      case 2: // Girlfriend (focus on girlfriend)
+        if (currentStage.getGirlfriend() == null)
+        {
+          trace('No GF to focus on.');
+          return;
+        }
+        trace('Focusing camera on girlfriend.');
+        var gfPoint = currentStage.getGirlfriend().cameraFocusPoint;
+        targetX += gfPoint.x;
+        targetY += gfPoint.y;
+
+      default:
+        trace('Unknown camera focus: ' + data);
+    }
+
+    // Apply tween based on ease.
+    switch (ease)
+    {
+      case 'CLASSIC': // Old-school. No ease. Just set follow point.
+        PlayState.instance.resetCamera(false, false, false);
+        PlayState.instance.cancelCameraFollowTween();
+        PlayState.instance.cameraFollowPoint.setPosition(targetX, targetY);
+      case 'INSTANT': // Instant ease. Duration is automatically 0.
+        PlayState.instance.tweenCameraToPosition(targetX, targetY, 0);
+      default:
+        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var easeFunctionName = '$ease$easeDir';
+        var easeFunction:Null<Float->Float> = ReflectUtil.field(FlxEase, easeFunctionName);
+        if (easeFunction == null)
+        {
+          trace('Invalid ease function: $easeFunctionName');
+          return;
+        }
+        PlayState.instance.tweenCameraToPosition(targetX, targetY, durSeconds, easeFunction);
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return 'Focus Camera';
+  }
+
+  /**
+   * ```
+   * {
+   *   "char": ENUM, // Which character to point to
+   *   "x": FLOAT, // Optional x offset
+   *   "y": FLOAT, // Optional y offset
+   * }
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: "char",
+      title: "Target",
+      defaultValue: DEFAULT_TARGET,
+      type: SongEventFieldType.ENUM,
+      keys: ["Position" => -1, "Player" => 0, "Opponent" => 1, "Girlfriend" => 2]
+    }, {
+      name: "x",
+      title: "X Position",
+      defaultValue: DEFAULT_X_POSITION,
+      step: 10.0,
+      type: SongEventFieldType.FLOAT,
+      units: "px"
+    }, {
+      name: "y",
+      title: "Y Position",
+      defaultValue: DEFAULT_Y_POSITION,
+      step: 10.0,
+      type: SongEventFieldType.FLOAT,
+      units: "px"
+    }, {
+      name: 'duration',
+      title: 'Duration',
+      defaultValue: DEFAULT_DURATION,
+      min: 0,
+      step: 0.5,
+      type: SongEventFieldType.FLOAT,
+      units: 'steps'
+    }, {
+      name: 'ease',
+      title: 'Easing Type',
+      defaultValue: DEFAULT_CAMERA_EASE,
+      type: SongEventFieldType.ENUM,
+      keys: ['Linear' => 'linear', 'Instant (Ignores duration)' => 'INSTANT', 'Classic (Ignores duration)' => 'CLASSIC', 'Sine' => 'sine', 'Quad' => 'quad', 'Cube' => 'cube', 'Quart' => 'quart', 'Quint' => 'quint', 'Expo' => 'expo', 'Smooth Step' => 'smoothStep', 'Smoother Step' => 'smootherStep', 'Elastic' => 'elastic', 'Back' => 'back', 'Bounce' => 'bounce', 'Circ ' => 'circ',]
+    }, {
+      name: 'easeDir',
+      title: 'Easing Direction',
+      defaultValue: SongEvent.DEFAULT_EASE_DIR,
+      type: SongEventFieldType.ENUM,
+      keys: ['In' => 'In', 'Out' => 'Out', 'In/Out' => 'InOut']
+    }]);
+  }
+}

--- a/preload/scripts/events/PlayAnimationSongEvent.hxc
+++ b/preload/scripts/events/PlayAnimationSongEvent.hxc
@@ -1,0 +1,111 @@
+package funkin.play.event;
+
+import flixel.FlxSprite;
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.character.BaseCharacter;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+
+/**
+ * This class handles song events which force a specific character or stage prop to play an animation.
+ */
+class PlayAnimationSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('PlayAnimation');
+  }
+
+  static final DEFAULT_TARGET:String = 'boyfriend';
+  static final DEFAULT_ANIM:String = 'idle';
+  static final DEFAULT_FORCE:Bool = false;
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    var targetName:Null<String> = data.getString('target');
+    if (targetName == null) targetName = DEFAULT_TARGET;
+
+    var anim = data.getString('anim');
+    if (anim == null) anim = DEFAULT_ANIM;
+
+    var force = data.getBool('force');
+    if (force == null) force = DEFAULT_FORCE;
+
+    var target:FlxSprite = null;
+
+    switch (targetName)
+    {
+      case 'boyfriend' | 'bf' | 'player':
+        trace('Playing animation $anim on boyfriend.');
+        target = PlayState.instance.currentStage.getBoyfriend();
+      case 'dad' | 'opponent':
+        trace('Playing animation $anim on dad.');
+        target = PlayState.instance.currentStage.getDad();
+      case 'girlfriend' | 'gf':
+        trace('Playing animation $anim on girlfriend.');
+        target = PlayState.instance.currentStage.getGirlfriend();
+      default:
+        target = PlayState.instance.currentStage.getNamedProp(targetName);
+        if (target == null) trace('Unknown animation target: $targetName');
+        else
+          trace('Fetched animation target $targetName from stage.');
+    }
+
+    if (target != null)
+    {
+      if (Std.isOfType(target, BaseCharacter))
+      {
+        var targetChar:BaseCharacter = target;
+        targetChar.tempVocals = force;
+        targetChar.playAnimation(anim, force, force);
+      }
+      else
+      {
+        target.animation.play(anim, force);
+      }
+    }
+    else
+    {
+      trace('Unknown PlayAnimation target: $targetName');
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return "Play Animation";
+  }
+
+  /**
+   * ```
+   * {
+   *   "target": STRING, // Name of character or prop to point to.
+   *   "anim": STRING, // Name of animation to play.
+   *   "force": BOOL, // Whether to force the animation to play.
+   * }
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'target',
+      title: 'Target',
+      type: SongEventFieldType.STRING,
+      defaultValue: DEFAULT_TARGET,
+    }, {
+      name: 'anim',
+      title: 'Animation',
+      type: SongEventFieldType.STRING,
+      defaultValue: DEFAULT_ANIM,
+    }, {
+      name: 'force',
+      title: 'Force',
+      type: SongEventFieldType.BOOL,
+      defaultValue: DEFAULT_FORCE
+    }]);
+  }
+}

--- a/preload/scripts/events/ScrollSpeedEvent.hxc
+++ b/preload/scripts/events/ScrollSpeedEvent.hxc
@@ -1,0 +1,162 @@
+package funkin.play.event;
+
+import flixel.tweens.FlxEase;
+import funkin.Conductor;
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+import funkin.util.ReflectUtil;
+
+/**
+ * This class handles song events which change the scroll speed of the chart.
+ * This affects the speed at which the notes move towards the strums.
+ *
+ * Example: Scroll speed change of both strums from 1x to 1.3x:
+ * ```
+ * {
+ *   'e': 'ScrollSpeed',
+ *   "v": {
+ *      "scroll": "1.3",
+ *      "duration": "4",
+ *      "ease": "linear",
+ *      "strumline": "both",
+ *      "absolute": false
+ *    }
+ * }
+ * ```
+ */
+class ScrollSpeedEvent extends SongEvent
+{
+  public function new()
+  {
+    super('ScrollSpeed', {
+      processOldEvents: true
+    });
+  }
+
+  static final DEFAULT_SCROLL:Float = 1;
+  static final DEFAULT_DURATION:Float = 4.0;
+  static final DEFAULT_ABSOLUTE:Bool = false;
+  static final DEFAULT_STRUMLINE:String = 'both'; // my special little trick
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState.
+    if (PlayState.instance == null) return;
+
+    var scroll:Float = data.getFloat('scroll') ?? DEFAULT_SCROLL;
+
+    var duration:Float = data.getFloat('duration') ?? DEFAULT_DURATION;
+
+    var ease:String = data.getString('ease') ?? SongEvent.DEFAULT_EASE;
+    var easeDir:String = data.getString('easeDir') ?? SongEvent.DEFAULT_EASE_DIR;
+
+    if (SongEvent.EASE_TYPE_DIR_REGEX.match(ease) || ease == "linear") easeDir = "";
+
+    var strumline:String = data.getString('strumline') ?? DEFAULT_STRUMLINE;
+
+    var absolute:Bool = data.getBool('absolute') ?? DEFAULT_ABSOLUTE;
+
+    var strumlineNames:Array<String> = [];
+
+    if (!absolute)
+    {
+      // If absolute is set to false, do the awesome multiplicative thing
+      scroll = scroll * (PlayState.instance?.currentChart?.scrollSpeed ?? 1.0);
+    }
+
+    switch (strumline)
+    {
+      case 'both':
+        strumlineNames = ['playerStrumline', 'opponentStrumline'];
+      default:
+        strumlineNames = [strumline + 'Strumline'];
+    }
+    // If it's a string, check the value.
+    switch (ease)
+    {
+      case 'INSTANT':
+        PlayState.instance.tweenScrollSpeed(scroll, 0, null, strumlineNames);
+      default:
+        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var easeFunctionName = '$ease$easeDir';
+        var easeFunction:Null<Float->Float> = ReflectUtil.field(FlxEase, easeFunctionName);
+        if (easeFunction == null)
+        {
+          trace('Invalid ease function: $easeFunctionName');
+          return;
+        }
+
+        PlayState.instance.tweenScrollSpeed(scroll, durSeconds, easeFunction, strumlineNames);
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return 'Scroll Speed';
+  }
+
+  /**
+   * ```
+   * {
+   *   'scroll': FLOAT, // Target scroll level.
+   *   'duration': FLOAT, // Duration in steps.
+   *   'ease': ENUM, // Easing function.
+   *   'easeDir': ENUM, // Easing function direction (In, Out, InOut).
+   *   'strumline': ENUM, // Which strumline to change
+   *   'absolute': BOOL, // True to set the scroll speed to the target level, false to set the scroll speed to (target level x base scroll speed)
+   * }
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'scroll',
+      title: 'Target Value',
+      defaultValue: DEFAULT_SCROLL,
+      min: 0.1,
+      step: 0.1,
+      type: SongEventFieldType.FLOAT,
+      units: 'x'
+    }, {
+      name: 'duration',
+      title: 'Duration',
+      defaultValue: DEFAULT_DURATION,
+      min: 0,
+      step: 0.5,
+      type: SongEventFieldType.FLOAT,
+      units: 'steps'
+    }, {
+      name: 'ease',
+      title: 'Easing Type',
+      defaultValue: SongEvent.DEFAULT_EASE,
+      type: SongEventFieldType.ENUM,
+      keys: ['Linear' => 'linear', 'Instant (Ignores duration)' => 'INSTANT', 'Sine' => 'sine', 'Quad' => 'quad', 'Cube' => 'cube', 'Quart' => 'quart', 'Quint' => 'quint', 'Expo' => 'expo', 'Smooth Step' => 'smoothStep', 'Smoother Step' => 'smootherStep', 'Elastic' => 'elastic', 'Back' => 'back', 'Bounce' => 'bounce', 'Circ ' => 'circ',]
+    }, {
+      name: 'easeDir',
+      title: 'Easing Direction',
+      defaultValue: SongEvent.DEFAULT_EASE_DIR,
+      type: SongEventFieldType.ENUM,
+      keys: ['In' => 'In', 'Out' => 'Out', 'In/Out' => 'InOut']
+    }, {
+      name: 'advanced',
+      title: 'Advanced',
+      type: SongEventFieldType.FRAME,
+      collapsible: true,
+      children: [{
+        name: 'strumline',
+        title: 'Target Strumline',
+        defaultValue: DEFAULT_STRUMLINE,
+        type: SongEventFieldType.ENUM,
+        keys: ['Both' => 'both', 'Player' => 'player', 'Opponent' => 'opponent']
+      }, {
+        name: 'absolute',
+        title: 'Absolute',
+        defaultValue: DEFAULT_ABSOLUTE,
+        type: SongEventFieldType.BOOL,
+      }]
+    }]);
+  }
+}

--- a/preload/scripts/events/SetCameraBopSongEvent.hxc
+++ b/preload/scripts/events/SetCameraBopSongEvent.hxc
@@ -1,0 +1,97 @@
+package funkin.play.event;
+
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+
+/**
+ * This class handles song events which change how the camera bops to the beat of the song.
+ *
+ * Example: Bop the camera twice as hard, once per beat (rather than once every four beats).
+ * ```
+ * {
+ *   'e': 'SetCameraBop',
+ *   'v': {
+ *    'intensity': 2.0,
+ *    'rate': 1,
+ *   }
+ * }
+ * ```
+ *
+ * Example: Reset the camera bop to default values.
+ * ```
+ * {
+ *   'e': 'SetCameraBop',
+ * 	 'v': {}
+ * }
+ * ```
+ */
+class SetCameraBopSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('SetCameraBop', {
+      processOldEvents: true
+    });
+  }
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null) return;
+
+    var rate:Float = data.getFloat('rate') ?? Constants.DEFAULT_ZOOM_RATE;
+    var offset:Float = data.getFloat('offset') ?? Constants.DEFAULT_ZOOM_OFFSET;
+    var intensity:Float = data.getFloat('intensity') ?? 1.0;
+
+    PlayState.instance.cameraBopIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity + 1.0;
+    PlayState.instance.hudCameraZoomIntensity = (Constants.DEFAULT_BOP_INTENSITY - 1.0) * intensity * 2.0;
+    PlayState.instance.cameraZoomRate = rate;
+    PlayState.instance.cameraZoomRateOffset = offset;
+    trace('Set camera zoom rate to ${PlayState.instance.cameraZoomRate}');
+  }
+
+  public override function getTitle():String
+  {
+    return 'Set Camera Bop';
+  }
+
+  /**
+   * ```
+   * {
+   *   'intensity': FLOAT, // Zoom amount
+   *   'rate': INT, // Zoom rate (beats/zoom)
+   * }
+   * ```
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'intensity',
+      title: 'Intensity',
+      defaultValue: Constants.DEFAULT_BOP_INTENSITY,
+      min: 0,
+      step: 0.1,
+      type: SongEventFieldType.FLOAT,
+      units: 'x'
+    }, {
+      name: 'offset',
+      title: 'Offset',
+      defaultValue: Constants.DEFAULT_ZOOM_OFFSET,
+      step: 0.25,
+      type: SongEventFieldType.FLOAT,
+      units: 'beats'
+    }, {
+      name: 'rate',
+      title: 'Rate',
+      defaultValue: Constants.DEFAULT_ZOOM_RATE,
+      min: 0,
+      step: 0.25,
+      type: SongEventFieldType.FLOAT,
+      units: 'beats/zoom'
+    }]);
+  }
+}

--- a/preload/scripts/events/SetHealthIconSongEvent.hxc
+++ b/preload/scripts/events/SetHealthIconSongEvent.hxc
@@ -1,0 +1,143 @@
+package funkin.play.event;
+
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+
+/**
+ * This class handles song events which change the player's health icon, or the opponent's health icon.
+ *
+ * Example: Set the health icon of the opponent to "tankman-bloody":
+ * ```
+ * {
+ *   'e': 'SetHealthIcon',
+ * 	 "v": {
+ * 	 	 "char": 1,
+ *     "id": "tankman-bloody",
+ *
+ * // Optional params:
+ *     "scale": 1.0,
+ *     "flipX": false,
+ *     "isPixel": false,
+ *     "offsetX": 0.0,
+ *     "offsetY": 0.0
+ *   }
+ * }
+ * ```
+ */
+class SetHealthIconSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('SetHealthIcon', {
+      processOldEvents: true
+    });
+  }
+
+  static final DEFAULT_CHAR:Int = 0;
+  static final DEFAULT_SCALE:Float = 1.0;
+  static final DEFAULT_FLIPX:Bool = false;
+  static final DEFAULT_ISPIXEL:Bool = false;
+  static final DEFAULT_SHOULDBOP:Bool = true;
+
+  static final DEFAULT_X_OFFSET:Float = 0.0;
+  static final DEFAULT_Y_OFFSET:Float = 0.0;
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState.
+    if (PlayState.instance == null) return;
+
+    // Works even if we are minimal mode.
+    // if (PlayState.instance.isMinimalMode) return;
+
+    var offsets:Array<Float> = [data.value.offsetX ?? DEFAULT_X_OFFSET, data.value.offsetY ?? DEFAULT_Y_OFFSET];
+
+    var healthIconData:HealthIconData = {
+      id: data.value.id ?? Constants.DEFAULT_HEALTH_ICON,
+      shouldBop: data.value.shouldBop ?? DEFAULT_SHOULDBOP,
+      scale: data.value.scale ?? DEFAULT_SCALE,
+      flipX: data.value.flipX ?? DEFAULT_FLIPX,
+      isPixel: data.value.isPixel ?? DEFAULT_ISPIXEL,
+      offsets: offsets,
+    };
+
+    switch (data?.value?.char ?? DEFAULT_CHAR)
+    {
+      case 0:
+        if (PlayState.instance.iconP1 != null)
+        {
+          trace('Applying Player health icon via song event: ${healthIconData.id}');
+          PlayState.instance.iconP1.configure(healthIconData);
+        }
+      case 1:
+        if (PlayState.instance.iconP2 != null)
+        {
+          trace('Applying Opponent health icon via song event: ${healthIconData.id}');
+          PlayState.instance.iconP2.configure(healthIconData);
+        }
+      default:
+        trace(' WARNING '.warning() + ' SetHealthIconSongEvent: Unknown character index ' + data.value.char);
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return 'Set Health Icon';
+  }
+
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'char',
+      title: 'Character',
+      defaultValue: DEFAULT_CHAR,
+      type: SongEventFieldType.ENUM,
+      keys: ['Player' => 0, 'Opponent' => 1],
+    }, {
+      name: 'id',
+      title: 'Health Icon ID',
+      defaultValue: Constants.DEFAULT_HEALTH_ICON,
+      type: SongEventFieldType.STRING,
+    }, {
+      name: 'shouldBop',
+      title: 'Should Bop?',
+      defaultValue: DEFAULT_SHOULDBOP,
+      type: SongEventFieldType.BOOL,
+    }, {
+      name: 'scale',
+      title: 'Scale',
+      defaultValue: DEFAULT_SCALE,
+      min: 0,
+      type: SongEventFieldType.FLOAT,
+    }, {
+      name: 'flipX',
+      title: 'Flip X?',
+      defaultValue: DEFAULT_FLIPX,
+      type: SongEventFieldType.BOOL,
+    }, {
+      name: 'advanced',
+      title: 'Advanced',
+      type: SongEventFieldType.FRAME,
+      collapsible: true,
+      children: [{
+        name: 'isPixel',
+        title: 'Is Pixel?',
+        defaultValue: DEFAULT_ISPIXEL,
+        type: SongEventFieldType.BOOL,
+      }, {
+        name: 'offsetX',
+        title: 'X Offset',
+        defaultValue: DEFAULT_X_OFFSET,
+        type: SongEventFieldType.FLOAT,
+      }, {
+        name: 'offsetY',
+        title: 'Y Offset',
+        defaultValue: DEFAULT_Y_OFFSET,
+        type: SongEventFieldType.FLOAT,
+      }]
+    }]);
+  }
+}

--- a/preload/scripts/events/SetTargetBopSpeedSongEvent.hxc
+++ b/preload/scripts/events/SetTargetBopSpeedSongEvent.hxc
@@ -1,0 +1,105 @@
+package funkin.play.event;
+
+import flixel.FlxSprite;
+import funkin.data.song.SongEventData;
+import funkin.data.event.SongEventSchema;
+import funkin.data.event.SongEventFieldType;
+import funkin.play.character.BaseCharacter;
+import funkin.play.event.SongEvent;
+import funkin.play.stage.Bopper;
+import funkin.play.PlayState;
+
+/**
+ * This class handles song events which changes dance speed of specific character or stage prop.
+ */
+class SetTargetBopSpeedSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('SetTargetBopSpeed');
+  }
+
+  static final DEFAULT_TARGET:String = 'boyfriend';
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    var targetName:Null<String> = data.getString('target');
+    if (targetName == null) targetName = DEFAULT_TARGET;
+
+    var rate = data.getFloat('rate');
+    if (rate == null) rate = Constants.DEFAULT_PROP_RATE;
+
+    var target:FlxSprite = null;
+
+    switch (targetName)
+    {
+      case 'boyfriend' | 'bf' | 'player':
+        trace('Set dance rate to $rate on boyfriend.');
+        target = PlayState.instance.currentStage.getBoyfriend();
+      case 'dad' | 'opponent':
+        trace('Set dance rate to $rate on dad.');
+        target = PlayState.instance.currentStage.getDad();
+      case 'girlfriend' | 'gf':
+        trace('Set dance rate to $rate on girlfriend.');
+        target = PlayState.instance.currentStage.getGirlfriend();
+      default:
+        target = PlayState.instance.currentStage.getNamedProp(targetName);
+        if (target == null) trace('Unknown target to set dance rate: $targetName');
+        else
+          trace('Set dance rate to $targetName from stage.');
+    }
+
+    if (target != null)
+    {
+      if (Std.isOfType(target, BaseCharacter))
+      {
+        var targetChar:BaseCharacter = target;
+        targetChar.danceEvery = rate;
+      }
+      else if (Std.isOfType(target, Bopper))
+      {
+        var targetProp:Bopper = target;
+        targetProp.danceEvery = rate;
+      }
+    }
+    else
+    {
+      trace('Unknown SetTargetBopSpeed target: $targetName');
+    }
+  }
+
+  public override function getTitle():String
+  {
+    return "Set Target Bop Speed";
+  }
+
+  /**
+   * ```
+   * {
+   *   "target": STRING, // Name of character or prop to point to.
+   *   "anim": STRING, // Name of animation to play.
+   * }
+   * ```
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'target',
+      title: 'Target',
+      type: SongEventFieldType.STRING,
+      defaultValue: DEFAULT_TARGET,
+    }, {
+      name: 'rate',
+      title: 'Rate',
+      defaultValue: Constants.DEFAULT_PROP_RATE,
+      min: 0,
+      step: 0.25,
+      type: SongEventFieldType.FLOAT,
+      units: 'beats/dance'
+    }]);
+  }
+}

--- a/preload/scripts/events/ZoomCameraSongEvent.hxc
+++ b/preload/scripts/events/ZoomCameraSongEvent.hxc
@@ -1,0 +1,164 @@
+package funkin.play.event;
+
+import flixel.tweens.FlxEase;
+import flixel.math.FlxPoint;
+import funkin.Conductor;
+import funkin.data.event.SongEventFieldType;
+import funkin.data.event.SongEventSchema;
+import funkin.data.song.SongEventData;
+import funkin.play.event.SongEvent;
+import funkin.play.PlayState;
+import funkin.ui.FullScreenScaleMode;
+import funkin.util.ReflectUtil;
+
+/**
+ * This class handles song events which change the zoom level of the camera.
+ *
+ * Example: Zoom to 1.3x:
+ * ```
+ * {
+ *   'e': 'ZoomCamera',
+ *   'v': 1.3
+ * }
+ * ```
+ */
+class ZoomCameraSongEvent extends SongEvent
+{
+  public function new()
+  {
+    super('ZoomCamera', {
+      processOldEvents: true
+    });
+  }
+
+  public static final DEFAULT_ZOOM:Float = 1.0;
+  public static final DEFAULT_WIDESCREEN_SCALE:Float = 0.0;
+  public static final DEFAULT_DURATION:Float = 4.0;
+  public static final DEFAULT_MODE:String = 'direct';
+
+  public override function handleEvent(data:SongEventData):Void
+  {
+    // Does nothing if there is no PlayState camera or stage.
+    if (PlayState.instance == null || PlayState.instance.currentStage == null) return;
+
+    // Does nothing if we are minimal mode.
+    if (PlayState.instance.isMinimalMode) return;
+
+    var zoom:Float = data.getFloat('zoom') ?? DEFAULT_ZOOM;
+
+    var widescreenScaleX:Float = data.getFloat('widescreenScaleX') ?? DEFAULT_WIDESCREEN_SCALE;
+    var widescreenScaleY:Float = data.getFloat('widescreenScaleY') ?? DEFAULT_WIDESCREEN_SCALE;
+
+    var scaledZoom:Float = zoom + (zoom * calculateScale(FullScreenScaleMode.wideScale, FlxPoint.get(widescreenScaleX, widescreenScaleY)));
+
+    var duration:Float = data.getFloat('duration') ?? DEFAULT_DURATION;
+
+    var mode:String = data.getString('mode') ?? DEFAULT_MODE;
+    var isDirectMode:Bool = mode == 'direct';
+
+    var ease:String = data.getString('ease') ?? SongEvent.DEFAULT_EASE;
+    var easeDir:String = data.getString('easeDir') ?? SongEvent.DEFAULT_EASE_DIR;
+
+    if (SongEvent.EASE_TYPE_DIR_REGEX.match(ease) || ease == "linear") easeDir = "";
+
+    // If it's a string, check the value.
+    switch (ease)
+    {
+      case 'INSTANT':
+        PlayState.instance.tweenCameraZoom(scaledZoom, 0, isDirectMode);
+      default:
+        var durSeconds = Conductor.instance.stepLengthMs * duration / 1000;
+        var easeFunctionName = '$ease$easeDir';
+        var easeFunction:Null<Float->Float> = ReflectUtil.field(FlxEase, easeFunctionName);
+        if (easeFunction == null)
+        {
+          trace('Invalid ease function: $easeFunctionName');
+          return;
+        }
+
+        PlayState.instance.tweenCameraZoom(scaledZoom, durSeconds, isDirectMode, easeFunction);
+    }
+  }
+
+  function calculateScale(wideScale:FlxPoint, scale:FlxPoint)
+  {
+    return (wideScale.x - 1) * scale.x + (wideScale.y - 1) * scale.y;
+  }
+
+  public override function getTitle():String
+  {
+    return 'Zoom Camera';
+  }
+
+  /**
+   * ```
+   * {
+   *   'zoom': FLOAT, // Target zoom level.
+   *   'duration': FLOAT, // Duration in steps.
+   *   'mode': ENUM, // Whether zoom is relative to the stage or absolute zoom.
+   *   'ease': ENUM, // Easing function.
+   *   'easeDir': ENUM, // Easing function direction (In, Out, InOut).
+   * }
+   * @return SongEventSchema
+   */
+  public override function getEventSchema():SongEventSchema
+  {
+    return new SongEventSchema([{
+      name: 'zoom',
+      title: 'Zoom Level',
+      defaultValue: DEFAULT_ZOOM,
+      min: 0,
+      step: 0.05,
+      type: SongEventFieldType.FLOAT,
+      units: 'x'
+    }, {
+      name: 'duration',
+      title: 'Duration',
+      defaultValue: DEFAULT_DURATION,
+      min: 0,
+      step: 0.5,
+      type: SongEventFieldType.FLOAT,
+      units: 'steps'
+    }, {
+      name: 'ease',
+      title: 'Easing Type',
+      defaultValue: SongEvent.DEFAULT_EASE,
+      type: SongEventFieldType.ENUM,
+      keys: ['Linear' => 'linear', 'Instant (Ignores duration)' => 'INSTANT', 'Sine' => 'sine', 'Quad' => 'quad', 'Cube' => 'cube', 'Quart' => 'quart', 'Quint' => 'quint', 'Expo' => 'expo', 'Smooth Step' => 'smoothStep', 'Smoother Step' => 'smootherStep', 'Elastic' => 'elastic', 'Back' => 'back', 'Bounce' => 'bounce', 'Circ ' => 'circ',]
+    }, {
+      name: 'easeDir',
+      title: 'Easing Direction',
+      defaultValue: SongEvent.DEFAULT_EASE_DIR,
+      type: SongEventFieldType.ENUM,
+      keys: ['In' => 'In', 'Out' => 'Out', 'In/Out' => 'InOut']
+    }, {
+      name: 'advanced',
+      title: 'Advanced',
+      type: SongEventFieldType.FRAME,
+      collapsible: true,
+      children: [{
+        name: 'mode',
+        title: 'Mode',
+        defaultValue: DEFAULT_MODE,
+        type: SongEventFieldType.ENUM,
+        keys: ['Stage zoom' => 'stage', 'Absolute zoom' => 'direct']
+      }, {
+        name: 'widescreenScaleX',
+        title: 'Widescreen Scale X',
+        defaultValue: DEFAULT_WIDESCREEN_SCALE,
+        min: 0,
+        max: 1,
+        type: SongEventFieldType.FLOAT,
+        units: 'x'
+      }, {
+        name: 'widescreenScaleY',
+        title: 'Widescreen Scale Y',
+        defaultValue: DEFAULT_WIDESCREEN_SCALE,
+        min: 0,
+        max: 1,
+        type: SongEventFieldType.FLOAT,
+        units: 'x'
+      }]
+    }]);
+  }
+}


### PR DESCRIPTION
## Associated Funkin PR
- https://github.com/FunkinCrew/Funkin/pull/7265

## Description
This PR just moves the SongEvent from hardcoded to scripts (softcoded).
Mostly to allow modders to override the events easier via mixins and keep the original scheme.