### PR TITLE
[BUGFIX] Pause background tankmen when pausing game

### DIFF
--- a/preload/scripts/songs/stress-pico.hxc
+++ b/preload/scripts/songs/stress-pico.hxc
@@ -228,6 +228,33 @@ class StressPicoMixSong extends Song
       PlayState.instance.endSong(true);
     });
   }
+    
+  /**
+   * Pause the tankman flicker when the game is paused
+   */
+  function onPause(event:ScriptEvent):Void
+  {
+    super.onPause(event);
+    if (tankmanGroup != null)
+    {
+      tankmanGroup.forEach(function(tankman)
+      {
+        tankman.tankmanFlicker?.pause();
+      });
+    }
+  }
+
+  function onResume(event:ScriptEvent):Void
+  {
+    super.onResume(event);
+    if (tankmanGroup != null)
+    {
+      tankmanGroup.forEach(function(tankman)
+      {
+        tankman.tankmanFlicker?.resume();
+      });
+    }
+  }
 
   function onDestroy(event:ScriptEvent):Void
   {

--- a/preload/scripts/songs/stress.hxc
+++ b/preload/scripts/songs/stress.hxc
@@ -112,6 +112,33 @@ class StressSong extends Song
       trace('reset pico!');
     }
   }
+  
+  /**
+   * Pause the tankman flicker when the game is paused
+   */
+  function onPause(event:ScriptEvent):Void
+  {
+    super.onPause(event);
+    if (tankmanGroup != null)
+    {
+      tankmanGroup.forEach(function(tankman)
+      {
+        tankman.tankmanFlicker?.pause();
+      });
+    }
+  }
+
+  function onResume(event:ScriptEvent):Void
+  {
+    super.onResume(event);
+    if (tankmanGroup != null)
+    {
+      tankmanGroup.forEach(function(tankman)
+      {
+        tankman.tankmanFlicker?.resume();
+      });
+    }
+  }
 
   function onDestroy(event:ScriptEvent):Void
   {


### PR DESCRIPTION
## Description
This PR fixes a visual bug where Tankman sprites would continue their death flickering animation even when the game was paused.

## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7298

## Changed
Added onPause and onResume functions to stress songs to control the death flicker for each tankman 