### PR TITLE
[BUGFIX] Remove sprite clipping on Vol 1 OST text asset

### DIFF
--- a/preload/images/freeplay/albumRoll/volume1-text.xml
+++ b/preload/images/freeplay/albumRoll/volume1-text.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TextureAtlas imagePath="volume1-text.png" width="468" height="133">
-  <SubTexture name="switch0001" x="234" y="0"  width="234" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="switch0002" x="234" y="0"  width="234" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="switch0003" x="234" y="0"  width="234" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="switch0004" x="234" y="0"  width="234" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0001" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0002" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0003" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0004" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0005" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0006" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0007" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
-  <SubTexture name="idle0008" x="0" y="0"  width="234" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="switch0001" x="234" y="0"  width="233" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="switch0002" x="234" y="0"  width="233" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="switch0003" x="234" y="0"  width="233" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="switch0004" x="234" y="0"  width="233" height="133" frameX="-0" frameY="-7" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0001" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0002" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0003" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0004" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0005" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0006" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0007" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
+  <SubTexture name="idle0008" x="0" y="0"  width="233" height="133" frameX="-0" frameY="-0" frameWidth="234" frameHeight="142"/>
 </TextureAtlas>


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

Fixes sprite clipping on the Vol 1 OST text in freeplay

Old/SO UNPLAYABLE

<img width="123" height="121" alt="image" src="https://github.com/user-attachments/assets/de287247-816b-48bb-b608-1ea829a580c5" />

New/FNF IS FIXED
<img width="189" height="177" alt="image" src="https://github.com/user-attachments/assets/1d855866-2617-40c6-bb39-c155766e94a8" />

