### PR TITLE
Fixed Chart Editor small typos

### DIFF
--- a/exclude/data/ui/chart-editor/toolboxes/difficulty.xml
+++ b/exclude/data/ui/chart-editor/toolboxes/difficulty.xml
@@ -10,7 +10,7 @@
         </hbox>
         <hbox>
             <button allowFocus="false" id="difficultyToolboxMoveDifficulty" text="Move Difficulty" tooltip="Rename the selected difficulty, or move it to a different variation." />
-            <button allowFocus="false" id="difficultyToolboxCloneDifficulty" text="Clone Difficulty" tooltip="Make a new difficulty with all the nodes and events of the current difficulty." />
+            <button allowFocus="false" id="difficultyToolboxCloneDifficulty" text="Clone Difficulty" tooltip="Make a new difficulty with all notes and events of the current difficulty." />
         </hbox>
         <hbox>
             <button allowFocus="false" id="difficultyToolboxRemoveDifficulty" text="Remove Difficulty" tooltip="Delete the selected difficulty." />

--- a/preload/data/ui/chart-editor/dialogs/add-difficulty.xml
+++ b/preload/data/ui/chart-editor/dialogs/add-difficulty.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<dialog id="addDifficultyDialog" width="300" height="210" title="Add Variation">
+<dialog id="addDifficultyDialog" width="300" height="210" title="Add Difficulty">
 	<vbox width="100%" height="100%">
 		<form id="difficultyForm" width="100%" height="100%">
 			<vbox width="100%" height="100%">


### PR DESCRIPTION
hip hip hooray!

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

i dont think so

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

no i just fixed typos

<!-- Briefly describe the issue(s) fixed. -->
## Description

i fixed two typos in the chart editor, where the Add Difficulty box still had "Add Variation" as the title, and "notes" were titled "nodes" in a description.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
What they looked like in game before my absolutely perfect fix:
<img width="597" height="474" alt="image" src="https://github.com/user-attachments/assets/07382fe2-4f90-4773-a9aa-c73c2427dcfa" />
<img width="650" height="66" alt="image" src="https://github.com/user-attachments/assets/78649786-d2fc-4578-9303-87c61b55c77d" />
