### PR TITLE
[BUGFIX] Fix Vocal Glitching After Opponent Pico Explodes

### DIFF
--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -335,11 +335,7 @@ class PhillyTrainErectStage extends Stage
   {
     super.onNoteHit(event);
     if (PlayState.instance.currentStage == null) return;
-    if (!event.note.noteData.getMustHitNote() && explode && playerShoots)
-    {
-      event.cancelEvent();
-      PlayState.instance.vocals.opponentVolume = 0;
-    }
+    if (!event.note.noteData.getMustHitNote() && explode && playerShoots) event.cancelEvent();
   }
 
   function buildStage()
@@ -397,6 +393,8 @@ class PhillyTrainErectStage extends Stage
         trainFrameTiming = 0;
       }
     }
+
+    if (explode && playerShoots) PlayState.instance.vocals.opponentVolume = 0;
 
     #if mobile
     isMobilePauseButtonPressed = TouchUtil.overlapsComplex(PlayState.instance.pauseButton) && TouchUtil.justPressed;


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
No associated PR.

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
No linked issues, as far as I know.

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR fixes the vocals for the opponent Pico playing for a split second after he exploded.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### Before:
https://github.com/user-attachments/assets/07777fea-7803-444c-be8e-fda9bb1d12c4

### After:
https://github.com/user-attachments/assets/3b15a135-3dfe-46b3-a94d-c46482217eae


