### PR TITLE
[BUGFIX] Fix Pico and Otis (Speakers) throwing errors in the Camera Editor

### DIFF
--- a/preload/scripts/characters/otis-speaker.hxc
+++ b/preload/scripts/characters/otis-speaker.hxc
@@ -5,6 +5,9 @@ import funkin.Conductor;
 import funkin.graphics.FunkinSprite;
 import funkin.audio.visualize.ABotVis;
 import funkin.graphics.shaders.AdjustColorShader;
+#if FEATURE_CAMERA_EDITOR
+import funkin.ui.debug.cameraeditor.CameraEditorState;
+#end
 
 class OtisSpeakerCharacter extends AnimateAtlasCharacter
 {
@@ -143,17 +146,25 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
     shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
-    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentVariation);
-    if (animChart == null)
+    var animNotes:Array<SongNoteData> = [];
+    #if FEATURE_CAMERA_EDITOR
+    if (Std.isOfType(FlxG.state, CameraEditorState))
+    {
+      animNotes = FlxG.state.currentSongChartData?.notes?.get('picospeaker')?.copy();
+    }
+    else
+    #end
+    {
+      animNotes = PlayState.instance.currentSong.getDifficulty('picospeaker', PlayState.instance.currentVariation)?.notes;
+    }
+
+    if (animNotes == null)
     {
       trace('Initializing Otis (speaker) failed; no `picospeaker` chart found for this song.');
       return;
     }
-    else
-    {
-      trace('Initializing Otis (speaker); found `picospeaker` chart, continuing...');
-    }
-    var animNotes:Array<SongNoteData> = animChart.notes;
+
+    trace('Initializing Otis (speaker); found `picospeaker` chart, continuing...');
 
     // turns out sorting functions are completely useless in polymod right now and do nothing
     // i had to sort the whole pico chart by hand im gonna go insane
@@ -186,32 +197,32 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
       abot.y = this.y + 455 - (-this.globalOffsets[1] * this.scale.y);
       abot.zIndex = this.zIndex - 10;
 
-      PlayState.instance.currentStage.add(abot);
+      currentStage.add(abot);
 
       abotViz.x = abot.x + 207;
       abotViz.y = abot.y + 84;
       abotViz.zIndex = abot.zIndex - 1;
-      PlayState.instance.currentStage.add(abotViz);
+      currentStage.add(abotViz);
 
       eyeWhites.x = abot.x + 40;
       eyeWhites.y = abot.y + 250;
       eyeWhites.zIndex = abot.zIndex - 10;
-      PlayState.instance.currentStage.add(eyeWhites);
+      currentStage.add(eyeWhites);
 
       pupil.x = abot.x + 50;
       pupil.y = abot.y + 238;
       pupil.zIndex = eyeWhites.zIndex + 5;
-      PlayState.instance.currentStage.add(pupil);
+      currentStage.add(pupil);
 
       stereoBG.x = abot.x + 150;
       stereoBG.y = abot.y + 30;
       stereoBG.zIndex = abot.zIndex - 8;
-      PlayState.instance.currentStage.add(stereoBG);
+      currentStage.add(stereoBG);
 
       muzzleFlash.zIndex = this.zIndex - 1;
-      PlayState.instance.currentStage.add(muzzleFlash);
+      currentStage.add(muzzleFlash);
 
-      PlayState.instance.currentStage.refresh();
+      currentStage.refresh();
       refershedLol = true;
     }
 

--- a/preload/scripts/characters/pico-speaker.hxc
+++ b/preload/scripts/characters/pico-speaker.hxc
@@ -7,6 +7,9 @@ import flixel.util.FlxSort;
 import funkin.Conductor;
 import funkin.util.SortUtil;
 import Lambda;
+#if FEATURE_CAMERA_EDITOR
+import funkin.ui.debug.cameraeditor.CameraEditorState;
+#end
 
 class PicoSpeakerCharacter extends AnimateAtlasCharacter
 {
@@ -51,17 +54,25 @@ class PicoSpeakerCharacter extends AnimateAtlasCharacter
     shootTimes = [];
     // The tankmen's timings and directions are determined
     // by the chart, specifically the internal "picospeaker" difficulty.
-    var animChart:SongDifficulty = PlayState.instance.currentSong.getDifficulty('picospeaker');
-    if (animChart == null)
+    var animNotes:Array<SongNoteData> = [];
+    #if FEATURE_CAMERA_EDITOR
+    if (Std.isOfType(FlxG.state, CameraEditorState))
+    {
+      animNotes = FlxG.state.currentSongChartData?.notes?.get('picospeaker')?.copy();
+    }
+    else
+    #end
+    {
+      animNotes = PlayState.instance.currentSong.getDifficulty('picospeaker')?.notes;
+    }
+
+    if (animNotes == null)
     {
       trace('Initializing Pico (speaker) failed; no `picospeaker` chart found for this song.');
       return;
     }
-    else
-    {
-      trace('Initializing Pico (speaker); found `picospeaker` chart, continuing...');
-    }
-    var animNotes:Array<SongNoteData> = animChart.notes;
+
+    trace('Initializing Pico (speaker); found `picospeaker` chart, continuing...');
 
     // turns out sorting functions are completely useless in polymod right now and do nothing
     // i had to sort the whole pico chart by hand im gonna go insane


### PR DESCRIPTION
## Associated Funkin PR
None.

## Linked Issues
:Maybe:

## Description
This PR fixes Pico (Speakers) and Otis (Speakers) throwing errors when used in the Camera Editor. It first checks if the state is `CameraEditorState`, before grabbing the notes from the `pico-speaker` difficulty.
For Otis (Speaker) I had to do a small additional change to get him working, which is changing instances of `PlayState.instance.currentStage` to just `currentStage`.

## Screenshots/Videos

https://github.com/user-attachments/assets/b5906159-35b6-4fa0-8e89-68906169b754
