### PR TITLE
[BUGFIX] Fix bottom bar not being rendered correctly in Stage Editor

### DIFF
--- a/exclude/data/ui/stage-editor/components/bottom-bar.xml
+++ b/exclude/data/ui/stage-editor/components/bottom-bar.xml
@@ -1,4 +1,18 @@
 <box id="bottomBar" width="100%" height="48" styleName="bottomBar" verticalAlign="bottom">
+  <style>
+    .bottomBar {
+      background-color: $solid-background-color;
+      padding: 8px;
+    }
+    .infoText {
+      font-size: 18px;
+      font-bold: true;
+      pointer-events: true;
+    }
+    .infoText:hover {
+      background-color: #CCCCCC;
+    }
+  </style>
   <hbox horizontalAlign="left" verticalAlign="center">
     <label id="bottomBarModeText" text="Assets" styleName="infoText" verticalAlign="center" tooltip="Click/TAB to swap between Character and Object modes."/>
     <rule direction="vertical" height="80%" />


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/7515
<!-- Briefly describe the issue(s) fixed. -->
## Description
In the migration to use CSS files, the style used by the bottom bar was accidentally removed, so this PR adds it back, and directly into the bottom bar file itself since these styles are pretty much only used there.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="1280" height="720" alt="screenshot-2026-05-03-17-57-09" src="https://github.com/user-attachments/assets/22f38d68-9c7b-4a3c-bf4d-61dd03d470d6" />
