### PR TITLE
[BUGFIX] Fix Pico Blazin' Game Over blood splatter snapping during confirm animation

### DIFF
--- a/preload/scripts/characters/pico-blazin.hxc
+++ b/preload/scripts/characters/pico-blazin.hxc
@@ -38,6 +38,8 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
   
   var cantUppercut = false;
 
+  var picoDeathTimer:FlxTimer = null;
+
   function onNoteHit(event:HitNoteScriptEvent)
   {
     holdTimer = 0;
@@ -134,12 +136,18 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
 
   function playAnimation(name:String, restart:Bool = false, ignoreOther:Bool = false, reversed:Bool = false)
   {
+    if (picoDeathTimer != null)
+    {
+      picoDeathTimer.cancel();
+      picoDeathTimer = null;
+    }
+
     if (name == "firstDeath")
     {
       // TODO: ACTUALLY play one of the three death animations here.
 
       // Make sure the death music plays with PERFECT timing.
-      new FlxTimer().start(1.25, _ -> afterPicoDeathGutPunchIntro());
+      picoDeathTimer = new FlxTimer().start(1.25, _ -> afterPicoDeathGutPunchIntro());
 
       if (HapticUtil.hapticsAvailable)
       {
@@ -155,10 +163,6 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
           });
         });
       }
-    }
-    else
-    {
-      super.playAnimation(name, restart, ignoreOther, reversed);
     }
 
     super.playAnimation(name, restart, ignoreOther, reversed);
@@ -296,6 +300,11 @@ class PicoBlazinCharacter extends AnimateAtlasCharacter
   override function onSongRetry()
   {
     super.onSongRetry();
+    if (picoDeathTimer != null)
+    {
+      picoDeathTimer.cancel();
+      picoDeathTimer = null;
+    }
     cantUppercut = false;
     playIdleAnim();
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes FunkinCrew/Funkin#7333

<!-- Briefly describe the issue(s) fixed. -->
## Description

Pico's blood splatter now persists into the deathConfirm animation when the user retries before the firstDeath fall-over animation finishes.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/a7c212b0-045e-4c8d-9796-449dd899c4a0