### PR TITLE
[BUGFIX] Nudge upperBoppers down 7px on mallXmasErect for Darnell

### DIFF
--- a/preload/data/stages/mallXmasErect.json
+++ b/preload/data/stages/mallXmasErect.json
@@ -14,7 +14,7 @@
     {
       "name": "upperBoppers",
       "assetPath": "christmas/erect/upperBop",
-      "position": [-374, -98],
+      "position": [-374, -91],
       "scale": [0.85, 0.85],
       "scroll": [0.28, 0.28],
       "danceEvery": 1,


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Fixes FunkinCrew/Funkin#7158

<!-- Briefly describe the issue(s) fixed. -->
## Description

During cocoa (pico mix) on Week 5 Erect, camera-zoom events made it look like Darnell rendered above where he should be. Actually, the `upperBoppers` parallax prop (scroll 0.28) was visually overlapping the DAD area at certain camera positions.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

https://github.com/user-attachments/assets/0475c2a6-53ab-4635-8641-a5e8e1c4a8d0

