### PR TITLE
[ENHANCEMENT] Remove Boyfriend's shader during game over in some stages

### DIFF
--- a/preload/scripts/stages/limoRideErect.hxc
+++ b/preload/scripts/stages/limoRideErect.hxc
@@ -214,6 +214,12 @@ class LimoRideErectStage extends Stage
     return results;
   }
 
+  override function onGameOver(event:ScriptEvent):Void
+  {
+    super.onGameOver(event);
+    getBoyfriend().shader = null;
+  }
+
   /**
    * Make sure the fast car is reset when the song restarts.
    */

--- a/preload/scripts/stages/mainStageErect.hxc
+++ b/preload/scripts/stages/mainStageErect.hxc
@@ -63,6 +63,12 @@ class MainStageErectStage extends Stage
     super.onStepHit(event);
   }
 
+  override function onGameOver(event:ScriptEvent):Void
+  {
+    super.onGameOver(event);
+    getBoyfriend().shader = null;
+  }
+
   /**
    * Apply the shader to the character as it is added.
    */

--- a/preload/scripts/stages/mallXmasErect.hxc
+++ b/preload/scripts/stages/mallXmasErect.hxc
@@ -32,6 +32,12 @@ class MallXmasErectStage extends Stage
     getNamedProp('bottomBoppers').shader = colorShaderBoppers;
   }
 
+  override function onGameOver(event:ScriptEvent):Void
+  {
+    super.onGameOver(event);
+    getBoyfriend().shader = null;
+  }
+
   override function addCharacter(character:BaseCharacter, charType:CharacterType):Void
   {
     // Apply the shader automatically to each character as it gets added.

--- a/preload/scripts/stages/phillyStreetsErect.hxc
+++ b/preload/scripts/stages/phillyStreetsErect.hxc
@@ -620,6 +620,7 @@ class PhillyStreetsErectStage extends Stage
     super.onGameOver(event);
     // Make it so the rain shader doesn't show over the game over screen
     FlxG.camera.filters = [];
+    getBoyfriend().shader = null;
   }
 
   override function onSongRetry(event:ScriptEvent):Void

--- a/preload/scripts/stages/phillyTrainErect.hxc
+++ b/preload/scripts/stages/phillyTrainErect.hxc
@@ -570,6 +570,12 @@ class PhillyTrainErectStage extends Stage
     if (explode && playerShoots) PlayState.instance.vocals.opponentVolume = 0;
   }
 
+  override function onGameOver(event:ScriptEvent):Void
+  {
+    super.onGameOver(event);
+    getBoyfriend().shader = null;
+  }
+
   override function onSongRetry(event:ScriptEvent)
   {
     super.onSongRetry(event);


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
none I could find

<!-- Briefly describe the issue(s) fixed. -->
## Description
Removes shaders from BF during game over in some stages.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
**Example (phillyStreetsErect):**
Before:
<img width="658" height="489" alt="image" src="https://github.com/user-attachments/assets/ad72cc4c-683d-4f13-b600-ed17b1c66015" />

After:
<img width="618" height="472" alt="image" src="https://github.com/user-attachments/assets/b12094e1-c551-4364-b637-6f879f65022b" />