### PR TITLE
[BUGFIX] Limit PicoBloodPool scale to prevent infinite growth

### DIFF
--- a/preload/scripts/stages/props/PicoBloodPool.hxc
+++ b/preload/scripts/stages/props/PicoBloodPool.hxc
@@ -30,8 +30,17 @@ class PicoBloodPool extends FunkinSprite
 
     if (extendBloodPool)
     {
-      var extendFactor:Float = 0.02 * elapsed;
-      this.scale.set(this.scale.x + extendFactor, this.scale.y + extendFactor);
+      var maxScale:Float = 7;
+
+      if (this.scale.x < maxScale)
+      {
+        var extendFactor:Float = 0.02 * elapsed;
+        this.scale.set(this.scale.x + extendFactor, this.scale.y + extendFactor);
+      }
+      else 
+      {
+        extendBloodPool = false; 
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
This PR fixes a bug where `PicoBloodPool` scales up infinitely during the update loop.

*Note for testing:* I temporarily changed `extendFactor` to `2 * elapsed` to make the blood pool scale faster for testing purposes.
## Screenshots/Videos
Before

https://github.com/user-attachments/assets/bd459fd8-086d-4d04-b47b-07e86f6589c7

After

https://github.com/user-attachments/assets/f73c7fb9-3cec-45ff-a0a3-811aaf4d0146

