### PR TITLE
[ENHANCEMENT] Add Auto-Place Camera Events menu item to chart editor

### DIFF
--- a/exclude/data/ui/chart-editor/components/menubar.xml
+++ b/exclude/data/ui/chart-editor/components/menubar.xml
@@ -46,6 +46,8 @@
         </vbox>
     </menu>
     <menu-separator />
+    <menu-item id="menubarItemAutoPlaceCameraEvents" text="Auto-Place Camera Events" tooltip="Scan the chart and place FocusCamera events at each singing-character switch." />
+    <menu-separator />
     <menu-item id="menubarItemSelectAllNotes" text="Select All Notes" shortcutText="Ctrl+A" />
     <menu-item id="menubarItemSelectAllEvents" text="Select All Events" shortcutText="Ctrl+Alt+A" />
     <menu-item id="menubarItemSelectInverse" text="Invert Selection" shortcutText="Ctrl+I" />


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

https://github.com/FunkinCrew/Funkin/pull/7638

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

Addresses FunkinCrew/Funkin#5624

<!-- Briefly describe the issue(s) fixed. -->
## Description

Adds the `menubarItemAutoPlaceCameraEvents` entry under the chart editor's Edit menu (between the Mirror Notes submenu and the Selection items), with a tooltip describing the action.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
