### PR TITLE
[BUGFIX] Fix Transparency on ColorAdjustShader

### DIFF
--- a/preload/shaders/adjustColor.frag
+++ b/preload/shaders/adjustColor.frag
@@ -21,7 +21,7 @@ vec3 applyHSBCEffect(vec3 color)
 
 void main()
 {
-	vec4 color4 = texture2D(bitmap, openfl_TextureCoordv);
+	vec4 color4 = flixel_texture2D(bitmap, openfl_TextureCoordv);
 	vec3 color3 = color4.a > 0.0 ? color4.rgb / color4.a : color4.rgb;
 
 	color3 = applyHSBCEffect(color3);


### PR DESCRIPTION
It appears that the new optimized color adjust shader has no alpha
So here is the one liner that saves the world! (it shouldnt make it less performant right...?)

<img width="1264" height="713" alt="image" src="https://github.com/user-attachments/assets/78012483-5e89-4748-a05b-f582fd96b75c" />

