### PR TITLE
[BUGFIX] Fix Thorns cutscene causing Spirit's icon to be ordered incorrectly

### DIFF
--- a/preload/scripts/songs/thorns.hxc
+++ b/preload/scripts/songs/thorns.hxc
@@ -92,7 +92,7 @@ class ThornsSong extends Song
           trace('Senpai death SFX done.');
           // Called when the sound completes. Clean up the cutscene here.
           // Hard cut to the cutscene.
-          PlayState.instance.remove(red);
+          PlayState.instance.remove(red, true);
 
           RetroCameraFade.fadeBlack(PlayState.instance.camCutscene, 6, 1.4);
           RetroCameraFade.fadeBlack(PlayState.instance.camGame, 6, 1.4);
@@ -110,7 +110,7 @@ class ThornsSong extends Song
           new FlxTimer().start(1.4, function(timer:FlxTimer)
           {
             red.color = 0xFFFFFFFF;
-            PlayState.instance.remove(senpaiCrazy);
+            PlayState.instance.remove(senpaiCrazy, true);
 
             PlayState.instance.camCutscene.filters = [];
             RetroCameraFade.fadeToBlack(PlayState.instance.camCutscene, 8, 0.8);


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/6671
<!-- Briefly describe the issue(s) fixed. -->
## Description

When each element from the cutscene was removed, they weren't being spliced. This meant they would leave a "hole" in the PlayState elements, which would cause a refresh to put some of them out of place. This is more noticeable due to compiler differences in the `sort` function used by arrays.
Shoutout to KoloInDaCrib for helping me have the basis for this fix.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
https://github.com/user-attachments/assets/40175226-b146-487f-ac21-0f75b841142c