### PR TITLE
Update holdNoteCover offsets and scale in funkin.json

### DIFF
--- a/preload/data/notestyles/funkin.json
+++ b/preload/data/notestyles/funkin.json
@@ -68,6 +68,8 @@
     },
     "holdNoteCover": {
       "assetPath": "",
+      "offsets": [6, 62],
+      "scale": 0.7,
       "offsets": [0, 0],
       "data": {
         "enabled": true,


### PR DESCRIPTION
## Associated Funkin PR
N/A

## Linked Issues
No issues linked.

## Description
Adjusts the size of hold covers, In my opinion they were a bit too big 😅 

## Screenshots/Videos
Before:
<img width="790" height="360" alt="bandicam2026-06-2212-35-03-608-ezgif com-resize" src="https://github.com/user-attachments/assets/345cad12-caf5-45aa-badb-57807c5c73e4" />

After:
<img width="790" height="360" alt="bandicam2026-06-2212-34-13-242-ezgif com-video-to-gif-converter" src="https://github.com/user-attachments/assets/a944afdf-f806-433d-990b-b824c42774f5" />