### PR TITLE
[BUGFIX] Switch lightning to individually check for null characters

### DIFF
--- a/preload/scripts/stages/spookyMansionErect.hxc
+++ b/preload/scripts/stages/spookyMansionErect.hxc
@@ -99,8 +99,6 @@ class SpookyMansionErectStage extends Stage
 
   function doLightningStrike(playSound:Bool, beat:Int):Void
   {
-    if (getBoyfriend() == null || getGirlfriend() == null || getDad() == null) return;
-
     if (playSound)
     {
       FunkinSound.playOnce(Paths.soundRandom('thunder_', 1, 2), 1.0);
@@ -109,9 +107,9 @@ class SpookyMansionErectStage extends Stage
     // getNamedProp('halloweenBG').animation.play('lightning');
     getNamedProp('bgLight').alpha = 1;
     getNamedProp('stairsLight').alpha = 1;
-    getBoyfriend().alpha = 0;
-    getDad().alpha = 0;
-    getGirlfriend().alpha = 0;
+    getBoyfriend()?.alpha = 0;
+    getDad()?.alpha = 0;
+    getGirlfriend()?.alpha = 0;
 
     lightningSequence = new Sequence(lightningSequenceData);
 
@@ -123,7 +121,7 @@ class SpookyMansionErectStage extends Stage
       getBoyfriend().playAnimation('scared', true, true);
     }
 
-    if (getGirlfriend().hasAnimation('scared'))
+    if (getGirlfriend() != null && getGirlfriend().hasAnimation('scared'))
     {
       getGirlfriend().playAnimation('scared', true, true);
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR switches the lightning strike to individually check if a character is null instead of having a return if one of the characters is null

Currently, if one of the characters is null, the lightning will not play at all. Meaning if a song were to not have a gf character the lightning will not play.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE:

https://github.com/user-attachments/assets/9d6a05db-8108-4508-ac89-0e4e857d2ebe

AFTER:

https://github.com/user-attachments/assets/43bec128-f3a4-4351-845c-8261efe58bae

