### PR TITLE
[BUGFIX] Match PhillyStreetsErect rain intensity to PhillyStreets

### DIFF
--- a/preload/scripts/stages/phillyStreetsErect.hxc
+++ b/preload/scripts/stages/phillyStreetsErect.hxc
@@ -136,13 +136,13 @@ class PhillyStreetsErectStage extends Stage
       {
         case "darnell":
           rainShaderStartIntensity = 0;
-          rainShaderEndIntensity = 0.01;
+          rainShaderEndIntensity = 0.1;
         case "lit-up":
-          rainShaderStartIntensity = 0.01;
-          rainShaderEndIntensity = 0.02;
+          rainShaderStartIntensity = 0.1;
+          rainShaderEndIntensity = 0.2;
         case "2hot":
-          rainShaderStartIntensity = 0.02;
-          rainShaderEndIntensity = 0.04;
+          rainShaderStartIntensity = 0.2;
+          rainShaderEndIntensity = 0.4;
       }
     }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7764

<!-- Briefly describe the issue(s) fixed. -->
## Description

Increases the amount of rain in the PhillyStreetsErect stage to match PhillyStreets, sense at the moment there is little to no visible rain (There is more rain on base Darnell than a 2hot remix)

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
