### PR TITLE
[WIP, FIX] Respect Preferences.naughtyness for cutscenes

### DIFF
--- a/preload/scripts/songs/darnell.hxc
+++ b/preload/scripts/songs/darnell.hxc
@@ -310,7 +310,7 @@ class DarnellSong extends Song
   {
     var videoPath = 'darnellCutscene';
 
-    if (Constants.CENSOR_EXPLETIVES)
+    if (!Preferences.naughtyness || Constants.CENSOR_EXPLETIVES)
     {
       videoPath += '-censored';
     }

--- a/preload/scripts/songs/stress-pico.hxc
+++ b/preload/scripts/songs/stress-pico.hxc
@@ -85,7 +85,7 @@ class StressPicoMixSong extends Song
   {
     var videoPath = 'stressPicoCutscene';
 
-    if (Constants.CENSOR_EXPLETIVES)
+    if (!Preferences.naughtyness || Constants.CENSOR_EXPLETIVES)
     {
       videoPath += '-censored';
     }

--- a/preload/scripts/songs/stress.hxc
+++ b/preload/scripts/songs/stress.hxc
@@ -83,7 +83,7 @@ class StressSong extends Song
   {
     var videoPath = 'stressCutscene';
 
-    if (Constants.CENSOR_EXPLETIVES)
+    if (!Preferences.naughtyness || Constants.CENSOR_EXPLETIVES)
     {
       videoPath += '-censored';
     }


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/7802

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7797

<!-- Briefly describe the issue(s) fixed. -->
## Description
This fixes the naughtiness preference not censoring any cutscenes when it is off, since it is dictated by an constant that only works on Mobile. At the moment this is still very much an WIP as it's still kind of debatable on how this should be or how it should work. Whether the constant should be reworked or not. I'm up for discussion on this though on how this should be. Like I said in the linked PR this is just my two cents on this and I don't expect this to get merged/approved

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos


https://github.com/user-attachments/assets/078a42f4-b771-4ea7-85ba-3145e5f91286

