### PR TITLE
[BUGFIX] Fix Spaghetti cutscene effects not playing correctly

### DIFF
--- a/gameplay/stages/sserafim/sserafim.hxc
+++ b/gameplay/stages/sserafim/sserafim.hxc
@@ -497,7 +497,7 @@ class SserafimStage extends Stage
     }
   }
 
-  function setDarkenAmt(darkAmt:Float, duration:Float)
+  function setDarkenAmt(darkAmt:Float, duration:Float, followConductor:Bool = true)
   {
     // Cancel previous darken tweens before starting new ones to prevent overlap.
     cancelAllEventTweens();
@@ -507,7 +507,7 @@ class SserafimStage extends Stage
     }, {
       conductor: Conductor.instance,
       lengthMs: duration * 1000,
-      shouldUseConductorSync: true,
+      shouldUseConductorSync: followConductor,
       ease: FlxEase.sineInOut
     });
     createEventTween(stageShader, {
@@ -515,7 +515,7 @@ class SserafimStage extends Stage
     }, {
       conductor: Conductor.instance,
       lengthMs: duration * 1000,
-      shouldUseConductorSync: true,
+      shouldUseConductorSync: followConductor,
       ease: FlxEase.sineInOut
     });
   }
@@ -921,11 +921,11 @@ class SserafimStage extends Stage
     {
       HapticUtil.vibrate(0, 0.1, 0.2, 0);
 
-      setDarkenAmt(0.2, 0.01);
+      setDarkenAmt(0.2, 0.01, false);
     });
     new FlxTimer(cutsceneTimerManager).start(251 / 24, function(tmr)
     {
-      setDarkenAmt(0, 0.8);
+      setDarkenAmt(0, 0.8, false);
     });
 
     // gf taps bf
@@ -933,11 +933,11 @@ class SserafimStage extends Stage
     {
       HapticUtil.vibrate(0, 0.1, 0.2, 0);
 
-      setDarkenAmt(0.2, 0.01);
+      setDarkenAmt(0.2, 0.01, false);
     });
     new FlxTimer(cutsceneTimerManager).start(411 / 24, function(tmr)
     {
-      setDarkenAmt(0, 0.8);
+      setDarkenAmt(0, 0.8, false);
     });
 
     // truck starts getting closer


### PR DESCRIPTION

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
N/A
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7864
## Description
The tweens responsible for the effects tried to follow a frozen conductor, causing the issue.
The fix makes the tweens act like a Flixel one, updating with the game instead.

## Screenshots/Videos
Just trust me, bro :ivebeenabadbrother: