### PR TITLE
[BUGFIX] Fix audio delay in Spaghetti's intro cutscene

### DIFF
--- a/gameplay/stages/sserafim/sserafim.hxc
+++ b/gameplay/stages/sserafim/sserafim.hxc
@@ -908,7 +908,7 @@ class SserafimStage extends Stage
 
     PlayState.instance.camGame.fade(0xFF000000, 3, true, null, true);
 
-    new FlxTimer(cutsceneTimerManager).start(20 / 24, function(tmr)
+    new FlxTimer(cutsceneTimerManager).start(14.5 / 24, function(tmr)
     {
       cutsceneSounds = FunkinSound.load(Paths.sound('gameplay/stages/sserafim/sounds/cutscene/start-cutscene'), 1.0, false, true, true);
     });


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
Fixes https://github.com/FunkinCrew/Funkin/issues/6660
<!-- Briefly describe the issue(s) fixed. -->
## Description
The audio for Spaghetti's intro cutscene has always been very slightly delayed. It's painfully noticeable if you pay attention to GF and BF's lip sync when they start speaking. This PR edits the `cutsceneTimerManager` for the cutscene by lowering the amount of time before the audio starts playing from ~0.833 seconds to ~0.604 seconds.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### ~0.833 seconds (original)

https://github.com/user-attachments/assets/909a8255-1d43-4853-b5b6-476ae03b6ed9

### ~0.604 seconds (fixed)

https://github.com/user-attachments/assets/cb98ef12-bdb1-43a6-a9f3-0f22d517e7d4

