### PR TITLE
[BUGFIX] Fix .color and AdjustColorShader not applying to same object

### DIFF
--- a/ui/shaders/adjust-color.frag
+++ b/ui/shaders/adjust-color.frag
@@ -21,7 +21,7 @@ vec3 applyHSBCEffect(vec3 color)
 
 void main()
 {
-	vec4 color4 = texture2D(bitmap, openfl_TextureCoordv);
+	vec4 color4 = flixel_texture2D(bitmap, openfl_TextureCoordv);
 	vec3 color3 = color4.a > 0.0 ? color4.rgb / color4.a : color4.rgb;
 
 	color3 = applyHSBCEffect(color3);


### PR DESCRIPTION
…same object

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7844

<!-- Briefly describe the issue(s) fixed. -->
## Description

Fixes a bug where if you were to try to use adjustColorShader and object.color on the same object they would cancel each other out

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

BEFORE
<img width="840" height="609" alt="image" src="https://github.com/user-attachments/assets/b575ee9e-7018-4ce9-8b93-709817b03bb4" />


AFTER (fixed)
<img width="547" height="393" alt="image" src="https://github.com/user-attachments/assets/4ded2157-ae6e-437f-8a18-4d736a780d82" />

One line change bugfixes my beloved