### PR TITLE
[BUGFIX] Adapt some stages for new DropShadowShader feature

### DIFF
--- a/gameplay/stages/schoolErect/schoolErect.hxc
+++ b/gameplay/stages/schoolErect/schoolErect.hxc
@@ -38,6 +38,7 @@ class SchoolErectStage extends Stage
     rim.color = 0xFF52351d;
     rim.attachedSprite = character;
     rim.distance = 5;
+    rim.normalizedSize = 96;
 
     switch (charType)
     {


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR

https://github.com/FunkinCrew/Funkin/pull/7942

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues

<!-- Briefly describe the issue(s) fixed. -->
## Description

Adapt week 6 for normalizedSize feature of DropShadowShader to avoid the characters looking weird

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos

<img width="1280" height="720" alt="BF-Normal on Week 6 Erect Stage" src="https://github.com/user-attachments/assets/6d8a0e02-ec81-488a-9252-e813f06e1cf2" />
