### PR TITLE
[BUGFIX] Fix Otis muzzle flash appearing at beginning of song

### DIFF
--- a/gameplay/characters/otis-speaker/otis-speaker.hxc
+++ b/gameplay/characters/otis-speaker/otis-speaker.hxc
@@ -163,6 +163,7 @@ class OtisSpeakerCharacter extends AnimateAtlasCharacter
     muzzleFlash.animation.addByPrefix('shoot2', 'shoot back low0', 24, false);
     muzzleFlash.animation.addByPrefix('shoot3', 'shoot forward0', 24, false);
     muzzleFlash.animation.addByPrefix('shoot4', 'shoot forward low0', 24, false);
+    muzzleFlash.visible = false;
 
     muzzleFlash.animation.onFrameChange.add(function()
     {


### PR DESCRIPTION
<!-- Does this PR close any issues? If so, link them below. -->
[## Linked Issues](https://github.com/FunkinCrew/Funkin/issues/7931)

<!-- Briefly describe the issue(s) fixed. -->
when playing stress pico mix, during the countdown of the song you can see otis's gun muzzle flash freeze on one frame
and then disappear once the song starts

<!-- Include any relevant screenshots or videos. -->
image from the issue
<img width="491" height="409" alt="image" src="https://github.com/user-attachments/assets/fcd2f0ee-5486-4e01-b233-bcbebd01a9fa" />

