### PR TITLE
[BUGFIX] Update cached sound paths in pico-playable.hxc 

### DIFF
--- a/gameplay/characters/pico-playable/pico-playable.hxc
+++ b/gameplay/characters/pico-playable/pico-playable.hxc
@@ -38,13 +38,13 @@ class PicoPlayerBaseCharacter extends MultiAnimateAtlasCharacter
   function get_CACHE_SOUND_PATHS():Array<String>
   {
     return [
-      'singed_loop',
-      'Gun_Prep',
-      'Pico_Bonk',
-      'shot1',
-      'shot2',
-      'shot3',
-      'shot4'
+      'gameplay/characters/pico-playable/sounds/singed',
+      'gameplay/characters/pico-playable/sounds/gun-prep',
+      'gameplay/characters/pico-playable/sounds/bonk',
+      'gameplay/characters/pico-playable/sounds/shot-1',
+      'gameplay/characters/pico-playable/sounds/shot-2',
+      'gameplay/characters/pico-playable/sounds/shot-3',
+      'gameplay/characters/pico-playable/sounds/shot-4'
     ];
   }
 
@@ -299,7 +299,7 @@ class PicoPlayerBaseCharacter extends MultiAnimateAtlasCharacter
     // Start the (standard) death music, 3.5 seconds after the explosion starts,
     // not when the explosion sound finishes or when the loop starts.
     GameOverSubState.instance.startDeathMusic(1.0, false);
-    singed = FunkinSound.load(NewPaths.sound('gameplay/characters/pico-playable/sounds/singed-loop').toFlxSoundAsset(), true, false, true);
+    singed = FunkinSound.load(NewPaths.sound('gameplay/characters/pico-playable/sounds/singed').toFlxSoundAsset(), true, false, true);
     // singed.fadeIn(0.5, 0.3, 1.0);
   }
 


### PR DESCRIPTION
- Updated to use the new path and file names.

<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
None.

<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
https://github.com/FunkinCrew/Funkin/issues/7970

<!-- Briefly describe the issue(s) fixed. -->
## Description
This PR aims to update ``pico-playable.hxc`` audio cache and the singed audio to refer to the new file paths rather than the old ones.

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
<img width="652" height="360" alt="image" src="https://github.com/user-attachments/assets/b237bb32-14b9-4e37-bbe7-b3bd15063349" />
