### PR TITLE
[BUGFIX] Rename Punch High (Spin) to Punch Low (Spin)

### DIFF
--- a/gameplay/notekinds/blazin.hxc
+++ b/gameplay/notekinds/blazin.hxc
@@ -60,7 +60,7 @@ class BlazinPunchLowSpinNoteKind extends NoteKind
 {
   public function new()
   {
-    super("weekend-1-punchlowspin", "Punch High (Spin) (Blazin')");
+    super("weekend-1-punchlowspin", "Punch Low (Spin) (Blazin')");
   }
 }
 


### PR DESCRIPTION
<!-- Please read the Contributing Guide (https://github.com/FunkinCrew/Funkin/blob/main/docs/CONTRIBUTING.md) before submitting this PR. -->

<!-- Is this PR associated with a PR from the main repo? If so, link it below. -->
## Associated Funkin PR
no
<!-- Does this PR close any issues? If so, link them below. -->
## Linked Issues
closes https://github.com/FunkinCrew/Funkin/issues/7273
<!-- Briefly describe the issue(s) fixed. -->
## Description
The BlazinPunchLowSpinNoteKind in assets/gameplay/notekinds/blazin.hxc used the wrong display label, showing `Punch High (Spin) (Blazin')` instead of `Punch Low (Spin) (Blazin')`. This made the Punch Low (Spin) option appear twice in the Chart Editor's Note Types list. Corrected the label to `Punch Low (Spin) (Blazin')`.
<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
### After :

<img width="1920" height="1080" alt="Screenshot (660)" src="https://github.com/user-attachments/assets/c4ce978e-c594-4b62-8bdc-c88f6502dce5" />
