### PR TITLE
[CONSISTENCY/FIX] Rename Enemy to Opponent & Reorder Chart Editor Volume Sliders

### DIFF
--- a/exclude/ui/editors/chart-editor/components/menubar.xml
+++ b/exclude/ui/editors/chart-editor/components/menubar.xml
@@ -110,14 +110,14 @@
     <menu-separator />
     <vbox width="100%" style="padding: 5px;">
       <label id="menubarLabelHitsoundVolume" width="100%" styleName="menuHeader" text="HITSOUNDS" />
-      <hbox width="100%" style="padding: 5px;">
+      <hbox width="100%">
+        <vbox width="50%">
+          <label id="menubarLabelVolumeHitsoundOpponent" styleName="menuLabel" text="Opponent - 100%" />
+          <slider id="menubarItemVolumeHitsoundOpponent" width="100%" majorTicks="20" minorTicks="10" pos="100" />
+        </vbox>
         <vbox width="50%">
           <label id="menubarLabelVolumeHitsoundPlayer" styleName="menuLabel" text="Player - 100%" />
           <slider id="menubarItemVolumeHitsoundPlayer" width="100%" majorTicks="20" minorTicks="10" pos="100" />
-        </vbox>
-        <vbox width="50%">
-          <label id="menubarLabelVolumeHitsoundOpponent" styleName="menuLabel" text="Enemy - 100%" />
-          <slider id="menubarItemVolumeHitsoundOpponent" width="100%" majorTicks="20" minorTicks="10" pos="100" />
         </vbox>
       </hbox>
     </vbox>
@@ -130,12 +130,12 @@
       </vbox>
       <hbox width="100%" style="padding: 5px;">
         <vbox width="50%">
-          <label id="menubarLabelVolumeVocalsPlayer" styleName="menuLabel" text="Player - 100%" />
-          <slider id="menubarItemVolumeVocalsPlayer" width="100%" majorTicks="20" minorTicks="10" pos="100" />
+          <label id="menubarLabelVolumeVocalsOpponent" styleName="menuLabel" text="Opponent - 100%" />
+          <slider id="menubarItemVolumeVocalsOpponent" width="100%" majorTicks="20" minorTicks="10" pos="100" />
         </vbox>
         <vbox width="50%">
-          <label id="menubarLabelVolumeVocalsOpponent" styleName="menuLabel" text="Enemy - 100%" />
-          <slider id="menubarItemVolumeVocalsOpponent" width="100%" majorTicks="20" minorTicks="10" pos="100" />
+          <label id="menubarLabelVolumeVocalsPlayer" styleName="menuLabel" text="Player - 100%" />
+          <slider id="menubarItemVolumeVocalsPlayer" width="100%" majorTicks="20" minorTicks="10" pos="100" />
         </vbox>
       </hbox>
     </vbox>


### PR DESCRIPTION
## Associated Funkin PR
https://github.com/FunkinCrew/Funkin/pull/8015

## Description
Really the term "Enemy" isn't used like anywhere, so I changed it to Opponent (like seen in other menus),
and moved the opponent volume sliders to the left to match with the rest of the game

<!-- Include any relevant screenshots or videos. -->
## Screenshots/Videos
_After_

<img width="374" height="491" alt="image" src="https://github.com/user-attachments/assets/30439c7a-eefe-4fe4-864f-5b1b7f2800cd" />

---
_Before_

<img width="325" height="486" alt="image" src="https://github.com/user-attachments/assets/25963c46-8987-4b25-9d0d-d1bd43656584" />