### PR TITLE
[ENHANCEMENT/BUGFIX] Rewrite wiggle shader.

### DIFF
--- a/preload/shaders/wiggle.frag
+++ b/preload/shaders/wiggle.frag
@@ -1,67 +1,61 @@
 #pragma header
 
-const int EFFECT_TYPE_DREAMY = 0;
-const int EFFECT_TYPE_WAVY = 1;
-const int EFFECT_TYPE_HEAT_WAVE_HORIZONTAL = 2;
-const int EFFECT_TYPE_HEAT_WAVE_VERTICAL = 3;
-const int EFFECT_TYPE_FLAG = 4;
+#define EFFECT_TYPE_DREAMY 0
+#define EFFECT_TYPE_WAVY 1
+#define EFFECT_TYPE_HEAT_WAVE_HORIZONTAL 2
+#define EFFECT_TYPE_HEAT_WAVE_VERTICAL 3
+#define EFFECT_TYPE_FLAG 4
 
-/**
- * The current time. Used to shift the effect over time.
- */
-uniform float uTime;		
-/**
- * Which out of several effects should be used.
- */
+// Which out of several effects should be used.
+uniform float uTime;
+
+// Which out of several effects should be used.
 uniform int effectType;
-/**
- * How fast the waves move over time.
- */
-uniform float uSpeed;		
-/**
- * Number of waves over time.
- */
-uniform float uFrequency;		
-/**
- * How much the pixels are going to stretch over the waves.
- */
+
+// How fast the waves move over time.
+uniform float uSpeed;
+
+// Number of waves over time.
+uniform float uFrequency;
+
+// How much the pixels are going to stretch over the waves.
 uniform float uWaveAmplitude;
 
-vec2 sineWave(vec2 pt) {
-	float x = 0.0;
-	float y = 0.0;
-			
-	if (effectType == EFFECT_TYPE_DREAMY) {
-		float w = 1.0 / openfl_TextureSize.y;
-		float h = 1.0 / openfl_TextureSize.x;
+// Whether to snap the UV coordinate to the center of the pixel. Set this to false for pixel art stuff.
+uniform bool antialiasing;
 
-		// look mom, I know how to write shaders now
+vec2 sineWave(vec2 pt){
+	vec2 offset = vec2(0.0);
+	vec2 pixelSize = vec2(1.0/openfl_TextureSize);
 
-		pt.x = floor(pt.x / h) * h;
-
-		float offsetX = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
-    
-		pt.y += floor(offsetX / w) * w; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
-		pt.y = floor(pt.y / w) * w;
-
-		float offsetY = sin(pt.y * (uFrequency / 2.0) + uTime * (uSpeed / 2.0)) * (uWaveAmplitude / 2.0);
-    pt.x += floor(offsetY / h) * h; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
-	} else if (effectType == EFFECT_TYPE_WAVY)  {
-		float offsetY = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
-		pt.y += offsetY; // * (pt.y - 1.0); // <- Uncomment to stop bottom part of the screen from moving
-	} else if (effectType == EFFECT_TYPE_HEAT_WAVE_HORIZONTAL) {
-		x = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
-	} else if (effectType == EFFECT_TYPE_HEAT_WAVE_VERTICAL) {
-		y = sin(pt.y * uFrequency + uTime * uSpeed) * uWaveAmplitude;
-	} else if (effectType == EFFECT_TYPE_FLAG) {
-		y = sin(pt.y * uFrequency + 10.0 * pt.x + uTime * uSpeed) * uWaveAmplitude;
-		x = sin(pt.x * uFrequency + 5.0 * pt.y + uTime * uSpeed) * uWaveAmplitude;
+	// Snap input UV to the pixel's center if antialiasing is disabled.
+	if(!antialiasing){
+		pt.x = floor(pt.x / pixelSize.x) * pixelSize.x + (pixelSize.x * 0.5);
+		pt.y = floor(pt.y / pixelSize.y) * pixelSize.y + (pixelSize.y * 0.5);
 	}
 			
-	return vec2(pt.x + x, pt.y + y);
+	if(effectType == EFFECT_TYPE_DREAMY){
+		offset.y = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
+		offset.x = sin((pt.y + offset.y) * (uFrequency / 2.0) + uTime * (uSpeed / 2.0)) * (uWaveAmplitude / 2.0);
+	}
+	else if(effectType == EFFECT_TYPE_WAVY){
+		offset.y = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
+	}
+	else if(effectType == EFFECT_TYPE_HEAT_WAVE_HORIZONTAL){
+		offset.x = sin(pt.x * uFrequency + uTime * uSpeed) * uWaveAmplitude;
+	}
+	else if(effectType == EFFECT_TYPE_HEAT_WAVE_VERTICAL){
+		offset.y = sin(pt.y * uFrequency + uTime * uSpeed) * uWaveAmplitude;
+	}
+	else if(effectType == EFFECT_TYPE_FLAG){
+		offset.y = sin(pt.y * uFrequency + 10.0 * pt.x + uTime * uSpeed) * uWaveAmplitude;
+		offset.x = sin(pt.x * uFrequency + 5.0 * pt.y + uTime * uSpeed) * uWaveAmplitude;
+	}
+					
+	return vec2(pt.x + offset.x, pt.y + offset.y);
 }
 
-void main() {
+void main(){
 	vec2 uv = sineWave(openfl_TextureCoordv);
-	gl_FragColor = texture2D(bitmap, uv);
+	gl_FragColor = flixel_texture2D(bitmap, uv);
 }


### PR DESCRIPTION
Rewrites the wiggle shader to be less confusing and fixes issue FunkinCrew/Funkin#7976 where the wiggle shader doesn't render correctly on certain GPUs due to precision issues. Also adds the ability to enable or disable pixel snapping across the whole shader instead of it being automatically disabled only on the dreamy effect.

Goes along with FunkinCrew/Funkin#8071.

Here are 2 videos [MistrDJ](https://github.com/MistrDJ) recorded for me since my GPU doesn't have the issue. The first is how the shader currently looks and the second is how it looks with this fix.

https://github.com/user-attachments/assets/5b492625-a92a-4e1f-a27f-77e1f94b9387

https://github.com/user-attachments/assets/1dedaf7f-d3bb-49d3-be01-9df66d3b2a6a

This shouldn't change how the shader looks at all in the context of how it is used in Week 6 as long as you didn't have the shader issue.